### PR TITLE
feat: Phase 2 PR 1 — client foundations (postWithBody, delete, put)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -101,13 +101,14 @@ proxmox_mcp/
 
 `InsecureSkipVerify` usage annotated with `//nolint:gosec // G402: user explicitly opted in via PROXMOX_INSECURE=true`.
 
-## Initial MCP Tools (v1)
+## Phase 1 MCP Tools (v0.1.0 — shipped)
 
 | Tool | Description | Params |
 |---|---|---|
 | `list_nodes` | List all nodes in the cluster | — |
 | `get_node_status` | Detailed status of a node | `node` |
 | `list_cluster_resources` | All resources across cluster | `type` (optional: vm, storage, node, sdn) |
+| `get_task_status` | Poll a Proxmox async task by UPID | `node`, `upid` |
 | `list_vms` | QEMU VMs on a node | `node` |
 | `get_vm_status` | VM status + current config | `node`, `vmid` |
 | `start_vm` | Start a VM | `node`, `vmid` |
@@ -119,9 +120,94 @@ proxmox_mcp/
 | `stop_container` | Stop a container | `node`, `vmid` |
 
 Lifecycle operations return task info immediately (non-blocking). Task status can be checked
-separately. Architecture is designed so that full CRUD (create/clone/delete VMs, snapshots,
-storage, migration, firewall, cluster config, etc.) can be added incrementally without
-restructuring.
+separately.
+
+---
+
+## Phase 2 — Full CRUD, Snapshots, Parity, Depth (target: v0.2.0)
+
+Delivered across 6 PRs in strict dependency order. Each PR must pass `make check` and CI
+before merge. Final tool count: **38 tools** (13 existing + 25 new).
+
+### PR 1 — Client foundations: `postWithBody`, `delete`, `put`
+
+Extends `internal/proxmox/client.go` with three new private methods. No new tools — pure
+client layer that all subsequent PRs depend on.
+
+- `postWithBody(ctx, path string, body, result any) error` — marshals body to JSON, sets
+  `Content-Type: application/json`. Required for create/clone/snapshot/migrate.
+- `delete(ctx, path string, result any) error` — sends DELETE. Required for
+  delete VM/container/snapshot.
+- `put(ctx, path string, body, result any) error` — sends PUT with JSON body. Required for
+  `set_vm_config` / `set_container_config` (Phase 3+).
+
+All three covered by `httptest`-based unit tests in `client_test.go`.
+
+### PR 2 — Lifecycle parity (5 new tools)
+
+Uses existing `post()` — no client changes needed.
+
+| Tool | API endpoint |
+|---|---|
+| `reboot_vm` | `POST /nodes/{node}/qemu/{vmid}/status/reboot` |
+| `suspend_vm` | `POST /nodes/{node}/qemu/{vmid}/status/suspend` |
+| `resume_vm` | `POST /nodes/{node}/qemu/{vmid}/status/resume` |
+| `shutdown_container` | `POST /nodes/{node}/lxc/{vmid}/status/shutdown` |
+| `reboot_container` | `POST /nodes/{node}/lxc/{vmid}/status/reboot` |
+
+All return a task ID via `taskResult(upid)`.
+
+### PR 3 — Snapshots (8 new tools)
+
+Depends on PR 1 (`postWithBody` for create, `delete` for delete).
+New file `internal/proxmox/snapshots.go`. New `Snapshot` struct in `types.go`.
+New file `tools/snapshots.go`. `RegisterAll` gains `registerSnapshotTools`.
+
+| Tool | Params |
+|---|---|
+| `list_vm_snapshots` | `node`, `vmid` |
+| `create_vm_snapshot` | `node`, `vmid`, `name`, `description`, `include_ram` |
+| `rollback_vm_snapshot` | `node`, `vmid`, `snapname` |
+| `delete_vm_snapshot` | `node`, `vmid`, `snapname` |
+| `list_container_snapshots` | `node`, `vmid` |
+| `create_container_snapshot` | `node`, `vmid`, `name`, `description` |
+| `rollback_container_snapshot` | `node`, `vmid`, `snapname` |
+| `delete_container_snapshot` | `node`, `vmid`, `snapname` |
+
+### PR 4 — Delete operations (2 new tools)
+
+Depends on PR 1 (`delete()` client method).
+`purge` defaults to `false` — disks are kept unless explicitly set to `true`.
+
+| Tool | Params |
+|---|---|
+| `delete_vm` | `node`, `vmid`, `purge` (bool, default false) |
+| `delete_container` | `node`, `vmid`, `purge` (bool, default false) |
+
+### PR 5 — Create and clone (4 new tools)
+
+Depends on PR 1 (`postWithBody`). New request structs `CreateVMRequest` and
+`CreateContainerRequest` in `types.go` expose a focused subset of Proxmox config options.
+
+| Tool | Params |
+|---|---|
+| `create_vm` | `node`, `vmid`, `name`, `memory`, `cores`, `iso`, `disk_size`, `start` |
+| `clone_vm` | `node`, `vmid`, `newid`, `name`, `target_node` |
+| `create_container` | `node`, `vmid`, `name`, `memory`, `disk_size`, `ostemplate`, `password`, `start` |
+| `clone_container` | `node`, `vmid`, `newid`, `name` |
+
+### PR 6 — Node and cluster depth (6 new tools)
+
+Read-only tools using existing `get()`. No client changes needed.
+
+| Tool | API endpoint |
+|---|---|
+| `get_cluster_status` | `GET /cluster/status` |
+| `list_node_storage` | `GET /nodes/{node}/storage` |
+| `list_node_tasks` | `GET /nodes/{node}/tasks` (params: `node`, `limit`) |
+| `get_node_disks` | `GET /nodes/{node}/disks/list` |
+| `get_vm_config` | `GET /nodes/{node}/qemu/{vmid}/config` |
+| `get_container_config` | `GET /nodes/{node}/lxc/{vmid}/config` |
 
 ## Proxmox API Notes
 

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -95,6 +96,69 @@ func (c *Client) post(ctx context.Context, path string, result any) error {
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			slog.Warn("closing post response body", "err", err)
+		}
+	}()
+
+	return c.decode(resp.Body, result)
+}
+
+// postWithBody performs an authenticated POST request to path with body
+// marshalled as JSON. The Proxmox {"data": ...} envelope is unwrapped and
+// decoded into result. Use this for create/clone/snapshot operations that
+// require a request body.
+func (c *Client) postWithBody(ctx context.Context, path string, body, result any) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshalling request body: %w", err)
+	}
+
+	resp, err := c.do(ctx, http.MethodPost, path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Warn("closing postWithBody response body", "err", err)
+		}
+	}()
+
+	return c.decode(resp.Body, result)
+}
+
+// delete performs an authenticated DELETE request to path (relative to
+// baseURL). The Proxmox {"data": ...} envelope is unwrapped and decoded into
+// result. Include query parameters directly in path where needed
+// (e.g. "/nodes/pve/qemu/100?purge=1").
+func (c *Client) delete(ctx context.Context, path string, result any) error {
+	resp, err := c.do(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Warn("closing delete response body", "err", err)
+		}
+	}()
+
+	return c.decode(resp.Body, result)
+}
+
+// put performs an authenticated PUT request to path with body marshalled as
+// JSON. The Proxmox {"data": ...} envelope is unwrapped and decoded into
+// result. Use this for updating VM/container configuration.
+func (c *Client) put(ctx context.Context, path string, body, result any) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshalling request body: %w", err)
+	}
+
+	resp, err := c.do(ctx, http.MethodPut, path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Warn("closing put response body", "err", err)
 		}
 	}()
 

--- a/internal/proxmox/client_test.go
+++ b/internal/proxmox/client_test.go
@@ -197,3 +197,185 @@ func TestClient_contextCancellation(t *testing.T) {
 		t.Fatal("expected error after context cancellation, got nil")
 	}
 }
+
+func TestClient_postWithBody_success(t *testing.T) {
+	t.Parallel()
+
+	type reqBody struct {
+		Name string `json:"name"`
+	}
+
+	const upid = "UPID:pve:000015E3:00000000:60F4B3A7:qmclone:100:root@pam:"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+			return
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			http.Error(w, "wrong content-type: "+ct, http.StatusBadRequest)
+			return
+		}
+		var body reqBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body.Name != "cloned-vm" {
+			http.Error(w, "unexpected name: "+body.Name, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, upid))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	var got string
+	if err := c.postWithBody(context.Background(), "/nodes/pve/qemu/100/clone", reqBody{Name: "cloned-vm"}, &got); err != nil {
+		t.Fatalf("postWithBody: %v", err)
+	}
+	if got != upid {
+		t.Errorf("got UPID %q, want %q", got, upid)
+	}
+}
+
+func TestClient_postWithBody_apiError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "insufficient permissions", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	var got string
+	err := c.postWithBody(context.Background(), "/nodes/pve/qemu/clone", map[string]any{"newid": 200}, &got)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Errorf("expected status 403, got %d", apiErr.StatusCode)
+	}
+}
+
+func TestClient_delete_success(t *testing.T) {
+	t.Parallel()
+
+	const upid = "UPID:pve:000015E3:00000000:60F4B3A7:qmdestroy:100:root@pam:"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, upid))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	var got string
+	if err := c.delete(context.Background(), "/nodes/pve/qemu/100", &got); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if got != upid {
+		t.Errorf("got UPID %q, want %q", got, upid)
+	}
+}
+
+func TestClient_delete_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	err := c.delete(context.Background(), "/nodes/pve/qemu/99999", nil)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestClient_delete_queryParams(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("purge") != "1" {
+			http.Error(w, "missing purge param", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, "ok"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	var got string
+	if err := c.delete(context.Background(), "/nodes/pve/qemu/100?purge=1", &got); err != nil {
+		t.Fatalf("delete with query params: %v", err)
+	}
+}
+
+func TestClient_put_success(t *testing.T) {
+	t.Parallel()
+
+	type configBody struct {
+		Memory int `json:"memory"`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+			return
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			http.Error(w, "wrong content-type: "+ct, http.StatusBadRequest)
+			return
+		}
+		var body configBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body.Memory != 2048 {
+			http.Error(w, "unexpected memory value", http.StatusBadRequest)
+			return
+		}
+		// Proxmox PUT /config returns null data on success.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, nil))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	if err := c.put(context.Background(), "/nodes/pve/qemu/100/config", configBody{Memory: 2048}, nil); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+}
+
+func TestClient_put_apiError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "parameter validation failed", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	err := c.put(context.Background(), "/nodes/pve/qemu/100/config", map[string]any{"memory": -1}, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", apiErr.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the three HTTP client methods that all subsequent Phase 2 PRs depend on. No new MCP tools — pure client layer.

## New methods in `internal/proxmox/client.go`

- `postWithBody(ctx, path, body, result)` — POST with JSON body (create/clone/snapshot ops)
- `delete(ctx, path, result)` — DELETE, query params passed in path (destroy ops)
- `put(ctx, path, body, result)` — PUT with JSON body (config update ops)

All three follow the existing pattern: context-bound, auth header, Proxmox `{"data":...}` envelope unwrapped, errors wrapped with `fmt.Errorf`.

## Tests

7 new `httptest`-based unit tests in `client_test.go` covering success, error, and edge cases for each method. All 33 tests pass with `-race`.

## Checklist

- [x] `make check` passes (fix, fmt, vet, lint, sec, vulncheck, test, build)
- [x] golangci-lint: 0 issues
- [x] gosec: 0 issues
- [x] govulncheck: no vulnerabilities

## Phase 2 PR sequence

- **PR 1 (this)** — client foundations
- PR 2 — lifecycle parity (reboot/suspend/resume/shutdown container)
- PR 3 — snapshots
- PR 4 — delete operations
- PR 5 — create and clone
- PR 6 — node and cluster depth
