### PR TITLE
feat: lifecycle parity — reboot, suspend, resume, shutdown

### DIFF
--- a/internal/proxmox/containers.go
+++ b/internal/proxmox/containers.go
@@ -48,3 +48,25 @@ func (c *Client) StopContainer(ctx context.Context, node string, vmid int) (stri
 	}
 	return upid, nil
 }
+
+// ShutdownContainer gracefully shuts down an LXC container via ACPI.
+// It returns the UPID of the asynchronous task.
+func (c *Client) ShutdownContainer(ctx context.Context, node string, vmid int) (string, error) {
+	var upid string
+	path := "/nodes/" + node + "/lxc/" + strconv.Itoa(vmid) + "/status/shutdown"
+	if err := c.post(ctx, path, &upid); err != nil {
+		return "", fmt.Errorf("shutting down container %d on node %s: %w", vmid, node, err)
+	}
+	return upid, nil
+}
+
+// RebootContainer reboots an LXC container. It returns the UPID of the
+// asynchronous task.
+func (c *Client) RebootContainer(ctx context.Context, node string, vmid int) (string, error) {
+	var upid string
+	path := "/nodes/" + node + "/lxc/" + strconv.Itoa(vmid) + "/status/reboot"
+	if err := c.post(ctx, path, &upid); err != nil {
+		return "", fmt.Errorf("rebooting container %d on node %s: %w", vmid, node, err)
+	}
+	return upid, nil
+}

--- a/internal/proxmox/containers_test.go
+++ b/internal/proxmox/containers_test.go
@@ -172,3 +172,61 @@ func TestStopContainer_apiError(t *testing.T) {
 		t.Errorf("expected *APIError, got %T: %v", err, err)
 	}
 }
+
+func TestShutdownContainer_success(t *testing.T) {
+	t.Parallel()
+
+	srv := ctLifecycleServer(t, "/nodes/pve1/lxc/200/status/shutdown")
+	defer srv.Close()
+
+	upid, err := newTestClient(t, srv.URL).ShutdownContainer(context.Background(), "pve1", 200)
+	if err != nil {
+		t.Fatalf("ShutdownContainer: %v", err)
+	}
+	if upid != ctUPID {
+		t.Errorf("upid: got %q, want %q", upid, ctUPID)
+	}
+}
+
+func TestShutdownContainer_apiError(t *testing.T) {
+	t.Parallel()
+	srv := ctErrorServer(t)
+	defer srv.Close()
+	_, err := newTestClient(t, srv.URL).ShutdownContainer(context.Background(), "pve1", 200)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+}
+
+func TestRebootContainer_success(t *testing.T) {
+	t.Parallel()
+
+	srv := ctLifecycleServer(t, "/nodes/pve1/lxc/200/status/reboot")
+	defer srv.Close()
+
+	upid, err := newTestClient(t, srv.URL).RebootContainer(context.Background(), "pve1", 200)
+	if err != nil {
+		t.Fatalf("RebootContainer: %v", err)
+	}
+	if upid != ctUPID {
+		t.Errorf("upid: got %q, want %q", upid, ctUPID)
+	}
+}
+
+func TestRebootContainer_apiError(t *testing.T) {
+	t.Parallel()
+	srv := ctErrorServer(t)
+	defer srv.Close()
+	_, err := newTestClient(t, srv.URL).RebootContainer(context.Background(), "pve1", 200)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+}

--- a/internal/proxmox/vms.go
+++ b/internal/proxmox/vms.go
@@ -59,3 +59,33 @@ func (c *Client) ShutdownVM(ctx context.Context, node string, vmid int) (string,
 	}
 	return upid, nil
 }
+
+// RebootVM reboots a QEMU VM. It returns the UPID of the asynchronous task.
+func (c *Client) RebootVM(ctx context.Context, node string, vmid int) (string, error) {
+	var upid string
+	path := "/nodes/" + node + "/qemu/" + strconv.Itoa(vmid) + "/status/reboot"
+	if err := c.post(ctx, path, &upid); err != nil {
+		return "", fmt.Errorf("rebooting VM %d on node %s: %w", vmid, node, err)
+	}
+	return upid, nil
+}
+
+// SuspendVM suspends a QEMU VM. It returns the UPID of the asynchronous task.
+func (c *Client) SuspendVM(ctx context.Context, node string, vmid int) (string, error) {
+	var upid string
+	path := "/nodes/" + node + "/qemu/" + strconv.Itoa(vmid) + "/status/suspend"
+	if err := c.post(ctx, path, &upid); err != nil {
+		return "", fmt.Errorf("suspending VM %d on node %s: %w", vmid, node, err)
+	}
+	return upid, nil
+}
+
+// ResumeVM resumes a suspended QEMU VM. It returns the UPID of the asynchronous task.
+func (c *Client) ResumeVM(ctx context.Context, node string, vmid int) (string, error) {
+	var upid string
+	path := "/nodes/" + node + "/qemu/" + strconv.Itoa(vmid) + "/status/resume"
+	if err := c.post(ctx, path, &upid); err != nil {
+		return "", fmt.Errorf("resuming VM %d on node %s: %w", vmid, node, err)
+	}
+	return upid, nil
+}

--- a/internal/proxmox/vms_test.go
+++ b/internal/proxmox/vms_test.go
@@ -201,3 +201,90 @@ func TestShutdownVM_apiError(t *testing.T) {
 		t.Errorf("expected *APIError, got %T: %v", err, err)
 	}
 }
+
+func TestRebootVM_success(t *testing.T) {
+	t.Parallel()
+
+	srv := vmLifecycleServer(t, "/nodes/pve1/qemu/100/status/reboot")
+	defer srv.Close()
+
+	upid, err := newTestClient(t, srv.URL).RebootVM(context.Background(), "pve1", 100)
+	if err != nil {
+		t.Fatalf("RebootVM: %v", err)
+	}
+	if upid != testUPID {
+		t.Errorf("upid: got %q, want %q", upid, testUPID)
+	}
+}
+
+func TestRebootVM_apiError(t *testing.T) {
+	t.Parallel()
+	srv := vmErrorServer(t)
+	defer srv.Close()
+	_, err := newTestClient(t, srv.URL).RebootVM(context.Background(), "pve1", 100)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+}
+
+func TestSuspendVM_success(t *testing.T) {
+	t.Parallel()
+
+	srv := vmLifecycleServer(t, "/nodes/pve1/qemu/100/status/suspend")
+	defer srv.Close()
+
+	upid, err := newTestClient(t, srv.URL).SuspendVM(context.Background(), "pve1", 100)
+	if err != nil {
+		t.Fatalf("SuspendVM: %v", err)
+	}
+	if upid != testUPID {
+		t.Errorf("upid: got %q, want %q", upid, testUPID)
+	}
+}
+
+func TestSuspendVM_apiError(t *testing.T) {
+	t.Parallel()
+	srv := vmErrorServer(t)
+	defer srv.Close()
+	_, err := newTestClient(t, srv.URL).SuspendVM(context.Background(), "pve1", 100)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+}
+
+func TestResumeVM_success(t *testing.T) {
+	t.Parallel()
+
+	srv := vmLifecycleServer(t, "/nodes/pve1/qemu/100/status/resume")
+	defer srv.Close()
+
+	upid, err := newTestClient(t, srv.URL).ResumeVM(context.Background(), "pve1", 100)
+	if err != nil {
+		t.Fatalf("ResumeVM: %v", err)
+	}
+	if upid != testUPID {
+		t.Errorf("upid: got %q, want %q", upid, testUPID)
+	}
+}
+
+func TestResumeVM_apiError(t *testing.T) {
+	t.Parallel()
+	srv := vmErrorServer(t)
+	defer srv.Close()
+	_, err := newTestClient(t, srv.URL).ResumeVM(context.Background(), "pve1", 100)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+}

--- a/tools/containers.go
+++ b/tools/containers.go
@@ -61,4 +61,26 @@ func registerContainerTools(s *mcp.Server, client *proxmox.Client) {
 		}
 		return taskResult(upid)
 	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "shutdown_container",
+		Description: "Gracefully shut down an LXC container via ACPI. Returns the async task ID.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input containerInput) (*mcp.CallToolResult, any, error) {
+		upid, err := client.ShutdownContainer(ctx, input.Node, input.VMID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("shutdown_container: %w", err)
+		}
+		return taskResult(upid)
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "reboot_container",
+		Description: "Reboot an LXC container. Returns the async task ID.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input containerInput) (*mcp.CallToolResult, any, error) {
+		upid, err := client.RebootContainer(ctx, input.Node, input.VMID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reboot_container: %w", err)
+		}
+		return taskResult(upid)
+	})
 }

--- a/tools/vms.go
+++ b/tools/vms.go
@@ -72,4 +72,37 @@ func registerVMTools(s *mcp.Server, client *proxmox.Client) {
 		}
 		return taskResult(upid)
 	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "reboot_vm",
+		Description: "Reboot a QEMU VM. Returns the async task ID.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input vmInput) (*mcp.CallToolResult, any, error) {
+		upid, err := client.RebootVM(ctx, input.Node, input.VMID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reboot_vm: %w", err)
+		}
+		return taskResult(upid)
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "suspend_vm",
+		Description: "Suspend a QEMU VM. Returns the async task ID.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input vmInput) (*mcp.CallToolResult, any, error) {
+		upid, err := client.SuspendVM(ctx, input.Node, input.VMID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("suspend_vm: %w", err)
+		}
+		return taskResult(upid)
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "resume_vm",
+		Description: "Resume a suspended QEMU VM. Returns the async task ID.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input vmInput) (*mcp.CallToolResult, any, error) {
+		upid, err := client.ResumeVM(ctx, input.Node, input.VMID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resume_vm: %w", err)
+		}
+		return taskResult(upid)
+	})
 }


### PR DESCRIPTION
## Phase 2 PR 2 — Lifecycle Parity

Adds the remaining lifecycle operations so VMs and containers have a complete and symmetric set of controls.

### New tools (5)

| Tool | Method | Proxmox API |
|---|---|---|
| `reboot_vm` | `RebootVM` | `POST /nodes/{node}/qemu/{vmid}/status/reboot` |
| `suspend_vm` | `SuspendVM` | `POST /nodes/{node}/qemu/{vmid}/status/suspend` |
| `resume_vm` | `ResumeVM` | `POST /nodes/{node}/qemu/{vmid}/status/resume` |
| `shutdown_container` | `ShutdownContainer` | `POST /nodes/{node}/lxc/{vmid}/status/shutdown` |
| `reboot_container` | `RebootContainer` | `POST /nodes/{node}/lxc/{vmid}/status/reboot` |

All tools return the async task UPID — use `get_task_status` to poll for completion.

### Changes
- `internal/proxmox/vms.go` — `RebootVM`, `SuspendVM`, `ResumeVM`
- `internal/proxmox/containers.go` — `ShutdownContainer`, `RebootContainer`
- `tools/vms.go` — `reboot_vm`, `suspend_vm`, `resume_vm` tools
- `tools/containers.go` — `shutdown_container`, `reboot_container` tools
- `internal/proxmox/vms_test.go` — success + error-path tests for all 3 new VM methods
- `internal/proxmox/containers_test.go` — success + error-path tests for both new container methods

### Total tool count: 18 (was 13)