### PR TITLE
feat: add delete_vm and delete_container with safety gates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ PROXMOX_TOKEN_SECRET=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 # Optional: Set to "true" if your Proxmox host uses a self-signed TLS certificate
 # Defaults to false (TLS verification enabled)
 PROXMOX_INSECURE=false
+
+# Optional: Set to "true" to enable destructive tools (delete_vm, delete_container)
+# Defaults to false — these tools are NOT registered unless explicitly opted in.
+# WARNING: enabling this allows permanent deletion of VMs and containers.
+PROXMOX_ALLOW_DESTRUCTIVE=false

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,7 @@ When `InsecureSkipVerify` is needed (Proxmox self-signed TLS), annotate with:
 | `PROXMOX_TOKEN_ID` | yes | e.g. `root@pam!mcp` |
 | `PROXMOX_TOKEN_SECRET` | yes | Token UUID |
 | `PROXMOX_INSECURE` | no | `true` to skip TLS verification |
+| `PROXMOX_ALLOW_DESTRUCTIVE` | no | `true` to register `delete_vm` and `delete_container` (default: disabled) |
 
 ## Security Rules — Non-Negotiable
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -38,11 +38,13 @@ proxmox_mcp/
 │       ├── containers.go     # LXC container API calls
 │       └── tasks.go          # task polling (UPID → status)
 ├── tools/
-│   ├── register.go           # RegisterAll() wires all tools onto the MCP server
+│   ├── register.go           # RegisterAll(cfg Config) wires all tools onto the MCP server
 │   ├── nodes.go              # node MCP tools
 │   ├── vms.go                # VM MCP tools
 │   ├── containers.go         # container MCP tools
-│   └── cluster.go            # cluster-wide MCP tools
+│   ├── cluster.go            # cluster-wide MCP tools
+│   ├── snapshots.go          # snapshot MCP tools (list/create/rollback/delete)
+│   └── destructive.go        # delete_vm, delete_container (opt-in via Config.AllowDestructive)
 ├── .golangci.yml             # linter config
 ├── Makefile                  # quality gate targets
 ├── go.mod
@@ -58,6 +60,7 @@ proxmox_mcp/
 | `PROXMOX_TOKEN_ID` | yes | Token ID, e.g. `root@pam!mcp` |
 | `PROXMOX_TOKEN_SECRET` | yes | Token UUID secret |
 | `PROXMOX_INSECURE` | no | Set `true` to skip TLS verification (self-signed certs) |
+| `PROXMOX_ALLOW_DESTRUCTIVE` | no | Set `true` to register `delete_vm` and `delete_container` tools (default: disabled) |
 
 ## CLI Flags
 
@@ -179,10 +182,17 @@ New file `tools/snapshots.go`. `RegisterAll` gains `registerSnapshotTools`.
 Depends on PR 1 (`delete()` client method).
 `purge` defaults to `false` — disks are kept unless explicitly set to `true`.
 
+**Safety design — 3 layers:**
+1. **Operator gate** — `PROXMOX_ALLOW_DESTRUCTIVE=true` required to register the tools at all. `tools.RegisterAll` accepts a `tools.Config{AllowDestructive bool}` struct; tools remain invisible to the MCP client unless opted in.
+2. **`DestructiveHint: true` annotation** — signals MCP clients to present confirmation UI before calling.
+3. **`confirmed: true` required field** — tool handler returns an error if `confirmed` is not explicitly set to `true`; the model must reason about the action before proceeding.
+
+New file `tools/destructive.go`. `tools.Config` struct added to `tools/register.go`. `RegisterAll` signature updated to accept `Config`.
+
 | Tool | Params |
 |---|---|
-| `delete_vm` | `node`, `vmid`, `purge` (bool, default false) |
-| `delete_container` | `node`, `vmid`, `purge` (bool, default false) |
+| `delete_vm` | `node`, `vmid`, `confirmed` (must be `true`), `purge` (bool, default false) |
+| `delete_container` | `node`, `vmid`, `confirmed` (must be `true`), `purge` (bool, default false) |
 
 ### PR 5 — Create and clone (4 new tools)
 

--- a/README.md
+++ b/README.md
@@ -4,23 +4,62 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 
 ## Tools
 
+### Cluster & Nodes
+
 | Tool | Description | Parameters |
 |---|---|---|
 | `list_nodes` | List all nodes in the cluster | — |
 | `get_node_status` | Detailed status of a node | `node` |
 | `list_cluster_resources` | All resources across the cluster | `type` (optional: `vm`, `storage`, `node`, `sdn`) |
+
+### QEMU VMs
+
+| Tool | Description | Parameters |
+|---|---|---|
 | `list_vms` | QEMU VMs on a node | `node` |
 | `get_vm_status` | VM status and current config | `node`, `vmid` |
 | `start_vm` | Start a VM (returns task UPID) | `node`, `vmid` |
 | `stop_vm` | Hard stop a VM (returns task UPID) | `node`, `vmid` |
 | `shutdown_vm` | Graceful ACPI shutdown (returns task UPID) | `node`, `vmid` |
+| `reboot_vm` | Reboot a VM (returns task UPID) | `node`, `vmid` |
+| `suspend_vm` | Suspend a VM (returns task UPID) | `node`, `vmid` |
+| `resume_vm` | Resume a suspended VM (returns task UPID) | `node`, `vmid` |
+| `list_vm_snapshots` | List all snapshots for a VM | `node`, `vmid` |
+| `create_vm_snapshot` | Create a VM snapshot (returns task UPID) | `node`, `vmid`, `snapname`, `description` (optional) |
+| `rollback_vm_snapshot` | Roll back a VM to a snapshot (returns task UPID) | `node`, `vmid`, `snapname` |
+| `delete_vm_snapshot` | Delete a VM snapshot (returns task UPID) | `node`, `vmid`, `snapname` |
+
+### LXC Containers
+
+| Tool | Description | Parameters |
+|---|---|---|
 | `list_containers` | LXC containers on a node | `node` |
 | `get_container_status` | Container status | `node`, `vmid` |
 | `start_container` | Start a container (returns task UPID) | `node`, `vmid` |
 | `stop_container` | Stop a container (returns task UPID) | `node`, `vmid` |
+| `shutdown_container` | Graceful ACPI shutdown (returns task UPID) | `node`, `vmid` |
+| `reboot_container` | Reboot a container (returns task UPID) | `node`, `vmid` |
+| `list_container_snapshots` | List all snapshots for a container | `node`, `vmid` |
+| `create_container_snapshot` | Create a container snapshot (returns task UPID) | `node`, `vmid`, `snapname`, `description` (optional) |
+| `rollback_container_snapshot` | Roll back a container to a snapshot (returns task UPID) | `node`, `vmid`, `snapname` |
+| `delete_container_snapshot` | Delete a container snapshot (returns task UPID) | `node`, `vmid`, `snapname` |
+
+### Tasks
+
+| Tool | Description | Parameters |
+|---|---|---|
 | `get_task_status` | Poll the status of an async task | `node`, `upid` |
 
-Lifecycle operations are non-blocking — they return the UPID of the async task immediately. Use `get_task_status` to poll for completion.
+### Destructive (opt-in)
+
+These tools are **not registered by default**. Set `PROXMOX_ALLOW_DESTRUCTIVE=true` to enable them.
+
+| Tool | Description | Parameters |
+|---|---|---|
+| `delete_vm` | Permanently delete a stopped QEMU VM (returns task UPID) | `node`, `vmid`, `confirmed` (must be `true`), `purge` (optional) |
+| `delete_container` | Permanently delete a stopped LXC container (returns task UPID) | `node`, `vmid`, `confirmed` (must be `true`), `purge` (optional) |
+
+Lifecycle and snapshot operations are non-blocking — they return the UPID of the async task immediately. Use `get_task_status` to poll for completion.
 
 ## Prerequisites
 
@@ -47,6 +86,7 @@ All configuration is via environment variables:
 | `PROXMOX_TOKEN_ID` | yes | e.g. `root@pam!mcp` |
 | `PROXMOX_TOKEN_SECRET` | yes | Token UUID secret |
 | `PROXMOX_INSECURE` | no | `true` to skip TLS verification (self-signed certs) |
+| `PROXMOX_ALLOW_DESTRUCTIVE` | no | `true` to register `delete_vm` and `delete_container` tools (default: disabled) |
 
 Source your `.env` file before running:
 

--- a/cmd/proxmox-mcp/main.go
+++ b/cmd/proxmox-mcp/main.go
@@ -9,7 +9,8 @@
 //
 // Optional environment variables:
 //
-//	PROXMOX_INSECURE     Set to "true" to skip TLS certificate verification
+//	PROXMOX_INSECURE          Set to "true" to skip TLS certificate verification
+//	PROXMOX_ALLOW_DESTRUCTIVE Set to "true" to enable delete_vm and delete_container tools
 //
 // Flags:
 //
@@ -61,6 +62,7 @@ func run() error {
 		return err
 	}
 	insecure := os.Getenv("PROXMOX_INSECURE") == "true"
+	allowDestructive := os.Getenv("PROXMOX_ALLOW_DESTRUCTIVE") == "true"
 
 	client, err := proxmox.NewClient(apiURL, tokenID, tokenSecret, insecure)
 	if err != nil {
@@ -72,7 +74,7 @@ func run() error {
 		Version: "v0.1.0",
 	}, nil)
 
-	tools.RegisterAll(server, client)
+	tools.RegisterAll(server, client, tools.Config{AllowDestructive: allowDestructive})
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/internal/proxmox/containers.go
+++ b/internal/proxmox/containers.go
@@ -70,3 +70,18 @@ func (c *Client) RebootContainer(ctx context.Context, node string, vmid int) (st
 	}
 	return upid, nil
 }
+
+// DeleteContainer deletes an LXC container. It returns the UPID of the
+// asynchronous task. If purge is true, associated disk images are also removed.
+// The container must be stopped before deletion.
+func (c *Client) DeleteContainer(ctx context.Context, node string, vmid int, purge bool) (string, error) {
+	var upid string
+	path := "/nodes/" + node + "/lxc/" + strconv.Itoa(vmid)
+	if purge {
+		path += "?purge=1"
+	}
+	if err := c.delete(ctx, path, &upid); err != nil {
+		return "", fmt.Errorf("deleting container %d on node %s: %w", vmid, node, err)
+	}
+	return upid, nil
+}

--- a/internal/proxmox/containers_test.go
+++ b/internal/proxmox/containers_test.go
@@ -230,3 +230,69 @@ func TestRebootContainer_apiError(t *testing.T) {
 		t.Errorf("expected *APIError, got %T: %v", err, err)
 	}
 }
+
+func TestDeleteContainer_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/nodes/pve1/lxc/200" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, ctUPID))
+	}))
+	defer srv.Close()
+
+	upid, err := newTestClient(t, srv.URL).DeleteContainer(context.Background(), "pve1", 200, false)
+	if err != nil {
+		t.Fatalf("DeleteContainer: %v", err)
+	}
+	if upid != ctUPID {
+		t.Errorf("upid: got %q, want %q", upid, ctUPID)
+	}
+}
+
+func TestDeleteContainer_purge(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/nodes/pve1/lxc/200" || r.URL.Query().Get("purge") != "1" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, ctUPID))
+	}))
+	defer srv.Close()
+
+	upid, err := newTestClient(t, srv.URL).DeleteContainer(context.Background(), "pve1", 200, true)
+	if err != nil {
+		t.Fatalf("DeleteContainer purge: %v", err)
+	}
+	if upid != ctUPID {
+		t.Errorf("upid: got %q, want %q", upid, ctUPID)
+	}
+}
+
+func TestDeleteContainer_apiError(t *testing.T) {
+	t.Parallel()
+	srv := ctErrorServer(t)
+	defer srv.Close()
+	_, err := newTestClient(t, srv.URL).DeleteContainer(context.Background(), "pve1", 200, false)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+}

--- a/internal/proxmox/vms.go
+++ b/internal/proxmox/vms.go
@@ -89,3 +89,18 @@ func (c *Client) ResumeVM(ctx context.Context, node string, vmid int) (string, e
 	}
 	return upid, nil
 }
+
+// DeleteVM deletes a QEMU VM. It returns the UPID of the asynchronous task.
+// If purge is true, associated disk images are also removed.
+// The VM must be stopped before deletion.
+func (c *Client) DeleteVM(ctx context.Context, node string, vmid int, purge bool) (string, error) {
+	var upid string
+	path := "/nodes/" + node + "/qemu/" + strconv.Itoa(vmid)
+	if purge {
+		path += "?purge=1"
+	}
+	if err := c.delete(ctx, path, &upid); err != nil {
+		return "", fmt.Errorf("deleting VM %d on node %s: %w", vmid, node, err)
+	}
+	return upid, nil
+}

--- a/internal/proxmox/vms_test.go
+++ b/internal/proxmox/vms_test.go
@@ -288,3 +288,69 @@ func TestResumeVM_apiError(t *testing.T) {
 		t.Errorf("expected *APIError, got %T: %v", err, err)
 	}
 }
+
+func TestDeleteVM_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/nodes/pve1/qemu/100" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, testUPID))
+	}))
+	defer srv.Close()
+
+	upid, err := newTestClient(t, srv.URL).DeleteVM(context.Background(), "pve1", 100, false)
+	if err != nil {
+		t.Fatalf("DeleteVM: %v", err)
+	}
+	if upid != testUPID {
+		t.Errorf("upid: got %q, want %q", upid, testUPID)
+	}
+}
+
+func TestDeleteVM_purge(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/nodes/pve1/qemu/100" || r.URL.Query().Get("purge") != "1" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, testUPID))
+	}))
+	defer srv.Close()
+
+	upid, err := newTestClient(t, srv.URL).DeleteVM(context.Background(), "pve1", 100, true)
+	if err != nil {
+		t.Fatalf("DeleteVM purge: %v", err)
+	}
+	if upid != testUPID {
+		t.Errorf("upid: got %q, want %q", upid, testUPID)
+	}
+}
+
+func TestDeleteVM_apiError(t *testing.T) {
+	t.Parallel()
+	srv := vmErrorServer(t)
+	defer srv.Close()
+	_, err := newTestClient(t, srv.URL).DeleteVM(context.Background(), "pve1", 100, false)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+}

--- a/tools/destructive.go
+++ b/tools/destructive.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gordcurrie/proxmox-mcp/internal/proxmox"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// destructiveHint is the *bool value used to set DestructiveHint on tools.
+var destructiveHint = true
+
+// registerDestructiveTools adds delete MCP tools to the server.
+// These tools are only registered when PROXMOX_ALLOW_DESTRUCTIVE=true.
+func registerDestructiveTools(s *mcp.Server, client *proxmox.Client) {
+	type deleteVMInput struct {
+		Node      string `json:"node"           jsonschema:"node the VM is on"`
+		VMID      int    `json:"vmid"           jsonschema:"numeric VM ID"`
+		Purge     bool   `json:"purge,omitempty" jsonschema:"also remove disk images and config (default false)"`
+		Confirmed bool   `json:"confirmed"      jsonschema:"must be set to true to confirm deletion"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "delete_vm",
+		Description: "Permanently delete a QEMU VM. The VM must be stopped first. Set confirmed=true to proceed. Optionally set purge=true to also remove disk images. Returns the async task ID.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: &destructiveHint,
+		},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input deleteVMInput) (*mcp.CallToolResult, any, error) {
+		if !input.Confirmed {
+			return nil, nil, errors.New("delete_vm: confirmed must be true to proceed with deletion")
+		}
+		upid, err := client.DeleteVM(ctx, input.Node, input.VMID, input.Purge)
+		if err != nil {
+			return nil, nil, fmt.Errorf("delete_vm: %w", err)
+		}
+		return taskResult(upid)
+	})
+
+	type deleteContainerInput struct {
+		Node      string `json:"node"           jsonschema:"node the container is on"`
+		VMID      int    `json:"vmid"           jsonschema:"numeric container ID"`
+		Purge     bool   `json:"purge,omitempty" jsonschema:"also remove disk images and config (default false)"`
+		Confirmed bool   `json:"confirmed"      jsonschema:"must be set to true to confirm deletion"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "delete_container",
+		Description: "Permanently delete an LXC container. The container must be stopped first. Set confirmed=true to proceed. Optionally set purge=true to also remove disk images. Returns the async task ID.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: &destructiveHint,
+		},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input deleteContainerInput) (*mcp.CallToolResult, any, error) {
+		if !input.Confirmed {
+			return nil, nil, errors.New("delete_container: confirmed must be true to proceed with deletion")
+		}
+		upid, err := client.DeleteContainer(ctx, input.Node, input.VMID, input.Purge)
+		if err != nil {
+			return nil, nil, fmt.Errorf("delete_container: %w", err)
+		}
+		return taskResult(upid)
+	})
+}

--- a/tools/register.go
+++ b/tools/register.go
@@ -6,11 +6,22 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// Config holds optional feature flags for tool registration.
+type Config struct {
+	// AllowDestructive enables destructive tools (delete_vm, delete_container).
+	// Corresponds to the PROXMOX_ALLOW_DESTRUCTIVE environment variable.
+	// Defaults to false — destructive tools are not registered unless explicitly opted in.
+	AllowDestructive bool
+}
+
 // RegisterAll wires all Proxmox MCP tools onto the provided server.
-func RegisterAll(s *mcp.Server, client *proxmox.Client) {
+func RegisterAll(s *mcp.Server, client *proxmox.Client, cfg Config) {
 	registerNodeTools(s, client)
 	registerVMTools(s, client)
 	registerContainerTools(s, client)
 	registerClusterTools(s, client)
 	registerSnapshotTools(s, client)
+	if cfg.AllowDestructive {
+		registerDestructiveTools(s, client)
+	}
 }


### PR DESCRIPTION
Adds `delete_vm` and `delete_container` tools with a 3-layer safety design to prevent accidental deletion.

## Safety design

**Layer 1 — Operator gate**
`PROXMOX_ALLOW_DESTRUCTIVE=true` must be set for the tools to be registered at all. Uses the same pattern as `PROXMOX_INSECURE`. If unset (or any value other than `"true"`), the tools are invisible to the MCP client.

**Layer 2 — `DestructiveHint: true` annotation**
Both tools carry `ToolAnnotations{DestructiveHint: true}`, signalling MCP clients to present confirmation UI before invoking.

**Layer 3 — `confirmed: true` required field**
The tool handler returns an error if `confirmed` is not explicitly `true`. The model must reason about the action and deliberately set the field — it cannot be called accidentally.

## Changes

- `internal/proxmox/vms.go` — `DeleteVM(ctx, node, vmid, purge bool) (string, error)`
- `internal/proxmox/containers.go` — `DeleteContainer(ctx, node, vmid, purge bool) (string, error)`
- `tools/destructive.go` — new file; `registerDestructiveTools` with `delete_vm` and `delete_container`
- `tools/register.go` — `tools.Config{AllowDestructive bool}` struct; `RegisterAll` accepts `Config`
- `cmd/proxmox-mcp/main.go` — reads `PROXMOX_ALLOW_DESTRUCTIVE` env var; passes to `tools.Config`
- `.env.example` — documents `PROXMOX_ALLOW_DESTRUCTIVE` with warning comment
- `README.md` — full tools table (all 29 tools), destructive section, updated config table
- `PLAN.md` / `copilot-instructions.md` — updated project structure, env vars, and PR 4 design notes

## Tests

- `TestDeleteVM_success`, `TestDeleteVM_purge` (verifies `?purge=1` query param), `TestDeleteVM_apiError`
- `TestDeleteContainer_success`, `TestDeleteContainer_purge`, `TestDeleteContainer_apiError`

`make check` passes clean.