### PR TITLE
feat: storage content tools — list, get, delete (Phase 3 PR 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 |---|---|---|
 | `get_task_status` | Poll the status of an async task | `node`, `upid` |
 
+### Storage Content
+
+| Tool | Description | Parameters |
+|---|---|---|
+| `list_storage_content` | List volumes in a storage pool | `node`, `storage`, `content` (optional: `iso`, `vztmpl`, `backup`, `images`) |
+| `get_storage_content_info` | Detailed info about a specific volume | `node`, `storage`, `volume` (full volid, e.g. `local:iso/debian.iso`) |
+
 ### Destructive (opt-in)
 
 These tools are **not registered by default**. Set `PROXMOX_ALLOW_DESTRUCTIVE=true` to enable them.
@@ -74,6 +81,7 @@ These tools are **not registered by default**. Set `PROXMOX_ALLOW_DESTRUCTIVE=tr
 |---|---|---|
 | `delete_vm` | Permanently delete a stopped QEMU VM (returns task UPID) | `node`, `vmid`, `confirmed` (must be `true`), `purge` (optional) |
 | `delete_container` | Permanently delete a stopped LXC container (returns task UPID) | `node`, `vmid`, `confirmed` (must be `true`), `purge` (optional) |
+| `delete_storage_content` | Permanently delete a volume from a storage pool (returns task UPID) | `node`, `storage`, `volume` (full volid), `confirmed` (must be `true`) |
 
 Lifecycle and snapshot operations are non-blocking — they return the UPID of the async task immediately. Use `get_task_status` to poll for completion.
 
@@ -102,7 +110,7 @@ All configuration is via environment variables:
 | `PROXMOX_TOKEN_ID` | yes | e.g. `root@pam!mcp` |
 | `PROXMOX_TOKEN_SECRET` | yes | Token UUID secret |
 | `PROXMOX_INSECURE` | no | `true` to skip TLS verification (self-signed certs) |
-| `PROXMOX_ALLOW_DESTRUCTIVE` | no | `true` to register `delete_vm` and `delete_container` tools (default: disabled) |
+| `PROXMOX_ALLOW_DESTRUCTIVE` | no | `true` to register `delete_vm`, `delete_container`, and `delete_storage_content` tools (default: disabled) |
 
 Source your `.env` file before running:
 

--- a/internal/proxmox/storage.go
+++ b/internal/proxmox/storage.go
@@ -1,0 +1,51 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// ListStorageContent returns the volumes stored in a storage pool on the
+// specified node. The optional content parameter filters by type (e.g. "iso",
+// "vztmpl", "backup", "images"). Pass an empty string to return all content.
+func (c *Client) ListStorageContent(ctx context.Context, node, storage, content string) ([]StorageContent, error) {
+	path := "/nodes/" + url.PathEscape(node) + "/storage/" + url.PathEscape(storage) + "/content"
+	if content != "" {
+		path += "?content=" + url.QueryEscape(content)
+	}
+
+	var result []StorageContent
+	if err := c.get(ctx, path, &result); err != nil {
+		return nil, fmt.Errorf("listing storage content on node %s storage %s: %w", node, storage, err)
+	}
+
+	return result, nil
+}
+
+// GetStorageContentInfo returns detailed information about a specific volume in
+// a storage pool. volume is the full volid, e.g. "local:iso/debian-12.iso".
+func (c *Client) GetStorageContentInfo(ctx context.Context, node, storage, volume string) (map[string]any, error) {
+	path := "/nodes/" + url.PathEscape(node) + "/storage/" + url.PathEscape(storage) + "/content/" + url.PathEscape(volume)
+
+	var result map[string]any
+	if err := c.get(ctx, path, &result); err != nil {
+		return nil, fmt.Errorf("getting storage content info for %s on node %s storage %s: %w", volume, node, storage, err)
+	}
+
+	return result, nil
+}
+
+// DeleteStorageContent deletes a volume from a storage pool. It returns the
+// UPID of the asynchronous task. volume is the full volid,
+// e.g. "local:iso/debian-12.iso".
+func (c *Client) DeleteStorageContent(ctx context.Context, node, storage, volume string) (string, error) {
+	path := "/nodes/" + url.PathEscape(node) + "/storage/" + url.PathEscape(storage) + "/content/" + url.PathEscape(volume)
+
+	var upid string
+	if err := c.delete(ctx, path, &upid); err != nil {
+		return "", fmt.Errorf("deleting storage content %s on node %s storage %s: %w", volume, node, storage, err)
+	}
+
+	return upid, nil
+}

--- a/internal/proxmox/storage_test.go
+++ b/internal/proxmox/storage_test.go
@@ -1,0 +1,173 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const storageDeleteUPID = "UPID:pve1:000015E3:00000000:60F4B3A7:imgdel:local:root@pam:"
+
+func TestListStorageContent_success(t *testing.T) {
+	t.Parallel()
+
+	want := []StorageContent{
+		{VolID: "local:iso/debian-12.iso", Content: "iso", Format: "iso", Size: 1234567890},
+		{VolID: "local:vztmpl/debian-12-standard.tar.zst", Content: "vztmpl", Format: "tar.zst", Size: 987654321},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nodes/pve1/storage/local/content" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListStorageContent(context.Background(), "pve1", "local", "")
+	if err != nil {
+		t.Fatalf("ListStorageContent: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d items, want %d", len(got), len(want))
+	}
+	for i, item := range got {
+		if item.VolID != want[i].VolID || item.Content != want[i].Content {
+			t.Errorf("item[%d]: got %+v, want %+v", i, item, want[i])
+		}
+	}
+}
+
+func TestListStorageContent_withContentFilter(t *testing.T) {
+	t.Parallel()
+
+	want := []StorageContent{
+		{VolID: "local:iso/debian-12.iso", Content: "iso", Format: "iso", Size: 1234567890},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nodes/pve1/storage/local/content" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("content") != "iso" {
+			http.Error(w, "want content=iso query param", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListStorageContent(context.Background(), "pve1", "local", "iso")
+	if err != nil {
+		t.Fatalf("ListStorageContent with filter: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d items, want 1", len(got))
+	}
+	if got[0].VolID != want[0].VolID {
+		t.Errorf("volid: got %q, want %q", got[0].VolID, want[0].VolID)
+	}
+}
+
+func TestListStorageContent_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).ListStorageContent(context.Background(), "missing", "local", "")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetStorageContentInfo_success(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]any{
+		"volid":   "local:iso/debian-12.iso",
+		"content": "iso",
+		"size":    float64(1234567890),
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != "/nodes/pve1/storage/local/content/local:iso%2Fdebian-12.iso" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).GetStorageContentInfo(context.Background(), "pve1", "local", "local:iso/debian-12.iso")
+	if err != nil {
+		t.Fatalf("GetStorageContentInfo: %v", err)
+	}
+	if got["volid"] != "local:iso/debian-12.iso" {
+		t.Errorf("volid: got %v, want local:iso/debian-12.iso", got["volid"])
+	}
+}
+
+func TestGetStorageContentInfo_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).GetStorageContentInfo(context.Background(), "pve1", "local", "local:iso/missing.iso")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDeleteStorageContent_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "want DELETE", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.EscapedPath() != "/nodes/pve1/storage/local/content/local:iso%2Fdebian-12.iso" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, storageDeleteUPID))
+	}))
+	defer srv.Close()
+
+	upid, err := newTestClient(t, srv.URL).DeleteStorageContent(context.Background(), "pve1", "local", "local:iso/debian-12.iso")
+	if err != nil {
+		t.Fatalf("DeleteStorageContent: %v", err)
+	}
+	if upid != storageDeleteUPID {
+		t.Errorf("upid: got %q, want %q", upid, storageDeleteUPID)
+	}
+}
+
+func TestDeleteStorageContent_apiError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "storage error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).DeleteStorageContent(context.Background(), "pve1", "local", "local:iso/debian-12.iso")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+}

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -235,6 +235,19 @@ type MigrateContainerRequest struct {
 	Restart *int   `json:"restart,omitempty"` // nil = omit; 1 = stop, migrate, restart on target
 }
 
+// StorageContent represents a single volume entry from
+// GET /nodes/{node}/storage/{storage}/content.
+type StorageContent struct {
+	VolID     string `json:"volid"`
+	Content   string `json:"content"`
+	Format    string `json:"format,omitempty"`
+	Size      int64  `json:"size,omitempty"`
+	CTime     int64  `json:"ctime,omitempty"`
+	VMID      int    `json:"vmid,omitempty"`
+	Notes     string `json:"notes,omitempty"`
+	Protected int    `json:"protected,omitempty"` // 1 if protected from deletion
+}
+
 // APIError represents an HTTP-level error returned by the Proxmox API.
 type APIError struct {
 	StatusCode int

--- a/tools/destructive.go
+++ b/tools/destructive.go
@@ -60,4 +60,27 @@ func registerDestructiveTools(s *mcp.Server, client *proxmox.Client) {
 		}
 		return taskResult(upid)
 	})
+
+	type deleteStorageContentInput struct {
+		Node      string `json:"node"      jsonschema:"node the storage pool is on"`
+		Storage   string `json:"storage"   jsonschema:"name of the storage pool (e.g. local)"`
+		Volume    string `json:"volume"    jsonschema:"volume ID to delete, e.g. local:iso/debian-12.iso"`
+		Confirmed bool   `json:"confirmed" jsonschema:"must be set to true to confirm deletion"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "delete_storage_content",
+		Description: "Permanently delete a volume from a Proxmox storage pool. Set confirmed=true to proceed. Returns the async task ID.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: &destructiveHint,
+		},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input deleteStorageContentInput) (*mcp.CallToolResult, any, error) {
+		if !input.Confirmed {
+			return nil, nil, errors.New("delete_storage_content: confirmed must be true to proceed with deletion")
+		}
+		upid, err := client.DeleteStorageContent(ctx, input.Node, input.Storage, input.Volume)
+		if err != nil {
+			return nil, nil, fmt.Errorf("delete_storage_content: %w", err)
+		}
+		return taskResult(upid)
+	})
 }

--- a/tools/register.go
+++ b/tools/register.go
@@ -21,6 +21,7 @@ func RegisterAll(s *mcp.Server, client *proxmox.Client, cfg Config) {
 	registerContainerTools(s, client)
 	registerClusterTools(s, client)
 	registerSnapshotTools(s, client)
+	registerStorageTools(s, client)
 	if cfg.AllowDestructive {
 		registerDestructiveTools(s, client)
 	}

--- a/tools/storage.go
+++ b/tools/storage.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gordcurrie/proxmox-mcp/internal/proxmox"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerStorageTools adds storage content MCP tools to the server.
+func registerStorageTools(s *mcp.Server, client *proxmox.Client) {
+	type listStorageContentInput struct {
+		Node    string `json:"node"              jsonschema:"name of the node (e.g. pve)"`
+		Storage string `json:"storage"           jsonschema:"name of the storage pool (e.g. local)"`
+		Content string `json:"content,omitempty" jsonschema:"optional content type filter: iso, vztmpl, backup, images"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_storage_content",
+		Description: "List the contents of a storage pool on a Proxmox node. Use the content filter to discover ISOs (iso), container templates (vztmpl), backups (backup), or disk images (images). Omit content to list all volumes.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input listStorageContentInput) (*mcp.CallToolResult, any, error) {
+		items, err := client.ListStorageContent(ctx, input.Node, input.Storage, input.Content)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list_storage_content: %w", err)
+		}
+		return jsonResult(items)
+	})
+
+	type getStorageContentInfoInput struct {
+		Node    string `json:"node"    jsonschema:"name of the node (e.g. pve)"`
+		Storage string `json:"storage" jsonschema:"name of the storage pool (e.g. local)"`
+		Volume  string `json:"volume"  jsonschema:"volume ID, e.g. local:iso/debian-12.iso"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_storage_content_info",
+		Description: "Get detailed information about a specific volume in a Proxmox storage pool. volume is the full volid, e.g. local:iso/debian-12.iso.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input getStorageContentInfoInput) (*mcp.CallToolResult, any, error) {
+		info, err := client.GetStorageContentInfo(ctx, input.Node, input.Storage, input.Volume)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get_storage_content_info: %w", err)
+		}
+		return jsonResult(info)
+	})
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 PR 9 from `PLAN.md` — storage content management.

## New tools

| Tool | Registered | Description |
|---|---|---|
| `list_storage_content` | Always | List volumes in a storage pool; optional `content` filter (`iso`, `vztmpl`, `backup`, `images`) |
| `get_storage_content_info` | Always | Detailed info for a specific volume by full volid |
| `delete_storage_content` | `PROXMOX_ALLOW_DESTRUCTIVE=true` only | Permanently delete a volume; requires `confirmed: true` |

## Safety — `delete_storage_content`

Follows the same 3-layer pattern as `delete_vm`/`delete_container`:
1. **Operator opt-in** — only registered when `PROXMOX_ALLOW_DESTRUCTIVE=true`
2. **`DestructiveHint`** annotation on the MCP tool
3. **`confirmed: true`** field — returns an error if not explicitly set

## Changes

- `internal/proxmox/types.go` — `StorageContent` struct
- `internal/proxmox/storage.go` — `ListStorageContent`, `GetStorageContentInfo`, `DeleteStorageContent`
- `internal/proxmox/storage_test.go` — 7 tests (success, notFound, apiError, content-filter)
- `tools/storage.go` — registers `list_storage_content` and `get_storage_content_info`
- `tools/destructive.go` — adds `delete_storage_content` with safety gate
- `tools/register.go` — calls `registerStorageTools`
- `README.md` — Storage Content section, destructive table updated, env var description updated

## Quality gates

All pass: `make check` (fix, fmt, vet, lint, gosec, vulncheck, test -race, build). 0 lint issues, 0 security issues.