### PR TITLE
feat: backup tools — create_backup and list_backups (Phase 3 PR 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 | `resize_container_disk` | Resize a container disk (returns task UPID) | `node`, `vmid`, `disk` (e.g. `rootfs`), `size` (e.g. `+5G` or `10G`) |
 | `migrate_container` | Migrate a container to another node (returns task UPID) | `node`, `vmid`, `target`, `restart` (optional, stop+migrate+start) |
 
+### Backups
+
+| Tool | Description | Parameters |
+|---|---|---|
+| `create_backup` | Create a vzdump backup of a VM or container (returns task UPID) | `node`, `vmid`, `storage` (optional), `mode` (optional: `snapshot`\|`suspend`\|`stop`, default `snapshot`), `compress` (optional: `zstd`\|`gzip`\|`lzo`\|`0`, default `zstd`) |
+| `list_backups` | List all backup volumes in a storage pool | `node`, `storage` |
+
 ### Tasks
 
 | Tool | Description | Parameters |

--- a/internal/proxmox/backup.go
+++ b/internal/proxmox/backup.go
@@ -1,0 +1,34 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// CreateBackup creates a backup of a VM or container via vzdump. It returns the
+// UPID of the asynchronous task. Use get_task_status to poll for completion.
+// Mode defaults to "snapshot" and compress defaults to "zstd" when omitted.
+func (c *Client) CreateBackup(ctx context.Context, node string, req *CreateBackupRequest) (string, error) {
+	if req == nil {
+		return "", errors.New("CreateBackup: req must not be nil")
+	}
+	var upid string
+	path := "/nodes/" + url.PathEscape(node) + "/vzdump"
+	if err := c.postWithBody(ctx, path, req, &upid); err != nil {
+		return "", fmt.Errorf("creating backup for vmid %d on node %s: %w", req.VMID, node, err)
+	}
+	return upid, nil
+}
+
+// ListBackups returns all backup volumes stored in the given storage pool on
+// the specified node. It is a convenience wrapper around ListStorageContent
+// filtered to content type "backup".
+func (c *Client) ListBackups(ctx context.Context, node, storage string) ([]StorageContent, error) {
+	backups, err := c.ListStorageContent(ctx, node, storage, "backup")
+	if err != nil {
+		return nil, fmt.Errorf("listing backups on node %s storage %s: %w", node, storage, err)
+	}
+	return backups, nil
+}

--- a/internal/proxmox/backup_test.go
+++ b/internal/proxmox/backup_test.go
@@ -1,0 +1,124 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const backupUPID = "UPID:pve1:000015E3:00000000:60F4B3A7:vzdump:100:root@pam:"
+
+func TestCreateBackup_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "want POST", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/nodes/pve1/vzdump" {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		if len(body) == 0 {
+			http.Error(w, "want non-empty body", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, backupUPID))
+	}))
+	defer srv.Close()
+
+	req := &CreateBackupRequest{
+		VMID:     100,
+		Storage:  "local",
+		Mode:     "snapshot",
+		Compress: "zstd",
+	}
+	upid, err := newTestClient(t, srv.URL).CreateBackup(context.Background(), "pve1", req)
+	if err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+	if upid != backupUPID {
+		t.Errorf("upid: got %q, want %q", upid, backupUPID)
+	}
+}
+
+func TestCreateBackup_apiError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "backup error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	req := &CreateBackupRequest{VMID: 100}
+	_, err := newTestClient(t, srv.URL).CreateBackup(context.Background(), "pve1", req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+}
+
+func TestCreateBackup_nilReq(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient(t, "http://localhost")
+	_, err := c.CreateBackup(context.Background(), "pve1", nil)
+	if err == nil {
+		t.Fatal("expected error for nil req, got nil")
+	}
+}
+
+func TestListBackups_success(t *testing.T) {
+	t.Parallel()
+
+	want := []StorageContent{
+		{VolID: "local:backup/vzdump-qemu-100-2024_01_01.vma.zst", Content: "backup", Format: "vma.zst", Size: 5368709120},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nodes/pve1/storage/local/content" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("content") != "backup" {
+			http.Error(w, "want content=backup query param", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListBackups(context.Background(), "pve1", "local")
+	if err != nil {
+		t.Fatalf("ListBackups: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d backups, want 1", len(got))
+	}
+	if got[0].VolID != want[0].VolID {
+		t.Errorf("volid: got %q, want %q", got[0].VolID, want[0].VolID)
+	}
+}
+
+func TestListBackups_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).ListBackups(context.Background(), "missing", "local")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -235,6 +235,15 @@ type MigrateContainerRequest struct {
 	Restart *int   `json:"restart,omitempty"` // nil = omit; 1 = stop, migrate, restart on target
 }
 
+// CreateBackupRequest is the request body for POST /nodes/{node}/vzdump.
+// All fields except VMID are optional — zero values use Proxmox defaults.
+type CreateBackupRequest struct {
+	VMID     int    `json:"vmid"`               // VM or container ID to back up
+	Storage  string `json:"storage,omitempty"`  // target storage pool
+	Mode     string `json:"mode,omitempty"`     // snapshot | suspend | stop (default: snapshot)
+	Compress string `json:"compress,omitempty"` // 0 | gzip | lzo | zstd (default: zstd)
+}
+
 // StorageContent represents a single volume entry from
 // GET /nodes/{node}/storage/{storage}/content.
 type StorageContent struct {

--- a/tools/backup.go
+++ b/tools/backup.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gordcurrie/proxmox-mcp/internal/proxmox"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerBackupTools adds backup MCP tools to the server.
+func registerBackupTools(s *mcp.Server, client *proxmox.Client) {
+	type createBackupInput struct {
+		Node     string `json:"node"              jsonschema:"name of the node the VM or container is on"`
+		VMID     int    `json:"vmid"              jsonschema:"numeric VM or container ID to back up"`
+		Storage  string `json:"storage,omitempty" jsonschema:"target storage pool for the backup"`
+		Mode     string `json:"mode,omitempty"    jsonschema:"backup mode: snapshot (default), suspend, or stop"`
+		Compress string `json:"compress,omitempty" jsonschema:"compression: zstd (default), gzip, lzo, or 0 (none)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "create_backup",
+		Description: "Create a backup of a QEMU VM or LXC container via vzdump. Returns the async task ID — use get_task_status to poll for completion. mode defaults to snapshot (no guest downtime when QEMU guest agent is running). compress defaults to zstd.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input createBackupInput) (*mcp.CallToolResult, any, error) {
+		req := &proxmox.CreateBackupRequest{
+			VMID:     input.VMID,
+			Storage:  input.Storage,
+			Mode:     input.Mode,
+			Compress: input.Compress,
+		}
+		upid, err := client.CreateBackup(ctx, input.Node, req)
+		if err != nil {
+			return nil, nil, fmt.Errorf("create_backup: %w", err)
+		}
+		return taskResult(upid)
+	})
+
+	type listBackupsInput struct {
+		Node    string `json:"node"    jsonschema:"name of the node"`
+		Storage string `json:"storage" jsonschema:"name of the storage pool to list backups from"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_backups",
+		Description: "List all backup volumes stored in a Proxmox storage pool on a node.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input listBackupsInput) (*mcp.CallToolResult, any, error) {
+		backups, err := client.ListBackups(ctx, input.Node, input.Storage)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list_backups: %w", err)
+		}
+		return jsonResult(backups)
+	})
+}

--- a/tools/register.go
+++ b/tools/register.go
@@ -22,6 +22,7 @@ func RegisterAll(s *mcp.Server, client *proxmox.Client, cfg Config) {
 	registerClusterTools(s, client)
 	registerSnapshotTools(s, client)
 	registerStorageTools(s, client)
+	registerBackupTools(s, client)
 	if cfg.AllowDestructive {
 		registerDestructiveTools(s, client)
 	}


### PR DESCRIPTION
## Summary

Completes Phase 3. Adds two new tools for Proxmox backup management via vzdump.

## New tools

| Tool | Description |
|---|---|
| `create_backup` | Trigger a vzdump backup for a VM or container. Async — returns a task UPID. `mode` defaults to `snapshot` (no guest downtime with QEMU agent). `compress` defaults to `zstd`. |
| `list_backups` | List all backup volumes in a storage pool. Convenience wrapper around `list_storage_content` filtered to `content=backup`. |

## Changes

- `internal/proxmox/types.go` — `CreateBackupRequest` struct
- `internal/proxmox/backup.go` — `CreateBackup` (via `postWithBody`) and `ListBackups` (delegates to `ListStorageContent`)
- `internal/proxmox/backup_test.go` — 5 tests: `success`, `apiError`, `nilReq` for `CreateBackup`; `success`, `notFound` for `ListBackups`
- `tools/backup.go` — registers both tools
- `tools/register.go` — calls `registerBackupTools`
- `README.md` — Backups section added

## Quality gates

All pass: `make check` (fix, fmt, vet, lint, gosec, vulncheck, test -race, build). 0 lint issues, 0 security issues.