### PR TITLE
chore: archive Phase 3, add CI note, write Phase 4 plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -289,7 +289,7 @@ Both return a task UPID — poll with `get_task_status`.
 
 Tests: success + apiError for both client methods (4 new tests).
 
-### PR #14 — Node network (3 new tools)
+### PR #14 — Node network (2 new tools)
 
 Read-only tools to inspect node networking — required context before creating VMs or
 containers that need specific bridges. All three get `ReadOnlyHint: true`.
@@ -331,7 +331,7 @@ data is preserved).
 
 Tests: success + apiError for all three (6 new tests).
 
-**Phase 4 target tool count:** 49 + 8 = **57 tools** (54 always-on + 5 destructive opt-in).
+**Phase 4 target tool count:** 49 + 7 = **56 tools** (51 always-on + 5 destructive opt-in).
 
 ---
 


### PR DESCRIPTION
Housekeeping update to `PLAN.md` before starting Phase 4 development.

**Phase 3 archived:**
- Marked `✅ shipped (v0.3.0)`
- Corrected PR numbers (`#8–#12`, not `#7–#10`)
- Updated final tool count to 49 (was 38 — missed the entire Phase 3 addition)

**CI noted:**
- Added `## CI — GitHub Actions ✅ in place` section documenting the two-job workflow (test + lint)

**Phase 4 written (target: v0.4.0):**

| PR | Tools | Summary |
|---|---|---|
| #13 | `restore_vm`, `restore_container` | Complete the backup lifecycle |
| #14 | `list_node_network`, `get_node_network_interface` | Network visibility before VM/CT creation |
| #15 | `reboot_node`, `shutdown_node` (destructive opt-in), `move_vm_disk` | Node power + disk relocation |

Target: **57 tools** (54 always-on + 5 destructive opt-in)