### PR TITLE
feat: add reboot_node, shutdown_node, and move_vm_disk tools (Phase 4 PR #15)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -304,7 +304,7 @@ New file `internal/proxmox/network.go`. New file `tools/network.go`.
 
 Tests: success + notFound for each (4 new tests).
 
-### PR #15 — Node power + disk move (3 new tools)
+### PR #15 — Node power + disk move (3 new tools) ✅
 
 Node-level power management and VM disk relocation. Two distinct API areas bundled because
 both are small and share the same PR quality overhead.
@@ -334,6 +334,7 @@ Tests: success + apiError for all three (6 new tests).
 **Phase 4 target tool count:** 49 + 7 = **56 tools** (51 always-on + 5 destructive opt-in).
 Running total after PR #13: **51 tools** (48 always-on + 3 destructive opt-in).
 Running total after PR #14: **53 tools** (50 always-on + 3 destructive opt-in).
+Running total after PR #15: **56 tools** (51 always-on + 5 destructive opt-in).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 | `resize_vm_disk` | Resize a VM disk (returns task UPID) | `node`, `vmid`, `disk` (e.g. `scsi0`), `size` (e.g. `+10G` or `50G`) |
 | `migrate_vm` | Migrate a VM to another node (returns task UPID) | `node`, `vmid`, `target`, `online` (optional, live migrate) |
 | `restore_vm` | Restore a VM from a vzdump backup archive (returns task UPID) | `node`, `vmid`, `archive` (volid), `storage` (optional), `start` (optional) |
+| `move_vm_disk` | Move a VM disk to a different storage pool (returns task UPID) | `node`, `vmid`, `disk` (e.g. `scsi0`), `storage` (target pool), `delete_source` (optional) |
 
 ### LXC Containers
 
@@ -98,6 +99,8 @@ These tools are **not registered by default**. Set `PROXMOX_ALLOW_DESTRUCTIVE=tr
 | `delete_vm` | Permanently delete a stopped QEMU VM (returns task UPID) | `node`, `vmid`, `confirmed` (must be `true`), `purge` (optional) |
 | `delete_container` | Permanently delete a stopped LXC container (returns task UPID) | `node`, `vmid`, `confirmed` (must be `true`), `purge` (optional) |
 | `delete_storage_content` | Permanently delete a volume from a storage pool (returns task UPID) | `node`, `storage`, `volume` (full volid), `confirmed` (must be `true`) |
+| `reboot_node` | Reboot an entire Proxmox node | `node`, `confirmed` (must be `true`) |
+| `shutdown_node` | Shut down an entire Proxmox node | `node`, `confirmed` (must be `true`) |
 
 Lifecycle and snapshot operations are non-blocking — they return the UPID of the async task immediately. Use `get_task_status` to poll for completion.
 
@@ -126,7 +129,7 @@ All configuration is via environment variables:
 | `PROXMOX_TOKEN_ID` | yes | e.g. `root@pam!mcp` |
 | `PROXMOX_TOKEN_SECRET` | yes | Token UUID secret |
 | `PROXMOX_INSECURE` | no | `true` to skip TLS verification (self-signed certs) |
-| `PROXMOX_ALLOW_DESTRUCTIVE` | no | `true` to register `delete_vm`, `delete_container`, and `delete_storage_content` tools (default: disabled) |
+| `PROXMOX_ALLOW_DESTRUCTIVE` | no | `true` to register `delete_vm`, `delete_container`, `delete_storage_content`, `reboot_node`, and `shutdown_node` tools (default: disabled) |
 
 Source your `.env` file before running:
 

--- a/internal/proxmox/nodes.go
+++ b/internal/proxmox/nodes.go
@@ -61,3 +61,15 @@ func (c *Client) GetNodeDisks(ctx context.Context, node string) ([]map[string]an
 	}
 	return disks, nil
 }
+
+// NodeCommand sends a power management command to a node.
+// command must be "reboot" or "shutdown". The operation is irreversible and
+// takes down the entire node, so callers must validate before invoking this.
+func (c *Client) NodeCommand(ctx context.Context, node, command string) error {
+	req := &NodeCommandRequest{Command: command}
+	var result any
+	if err := c.postWithBody(ctx, "/nodes/"+url.PathEscape(node)+"/status", req, &result); err != nil {
+		return fmt.Errorf("sending command %q to node %s: %w", command, node, err)
+	}
+	return nil
+}

--- a/internal/proxmox/nodes_test.go
+++ b/internal/proxmox/nodes_test.go
@@ -2,7 +2,9 @@ package proxmox
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -251,5 +253,55 @@ func TestGetNodeDisks_notFound(t *testing.T) {
 	_, err := newTestClient(t, srv.URL).GetNodeDisks(context.Background(), "missing")
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestNodeCommand_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "want POST", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/nodes/pve1/status" {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		if payload["command"] != "reboot" {
+			http.Error(w, "wrong command", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, nil))
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(t, srv.URL).NodeCommand(context.Background(), "pve1", "reboot"); err != nil {
+		t.Fatalf("NodeCommand: %v", err)
+	}
+}
+
+func TestNodeCommand_apiError(t *testing.T) {
+	t.Parallel()
+	srv := vmErrorServer(t)
+	defer srv.Close()
+	err := newTestClient(t, srv.URL).NodeCommand(context.Background(), "pve1", "reboot")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
 	}
 }

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -279,6 +279,22 @@ type StorageContent struct {
 	Protected int    `json:"protected,omitempty"` // 1 if protected from deletion
 }
 
+// NodeCommandRequest is the request body for POST /nodes/{node}/status.
+// Command must be one of "reboot" or "shutdown".
+type NodeCommandRequest struct {
+	Command string `json:"command"` // "reboot" or "shutdown"
+}
+
+// MoveVMDiskRequest is the request body for
+// POST /nodes/{node}/qemu/{vmid}/move_disk.
+// The disk is moved to a different storage pool. If DeleteSource is true the
+// source volume is removed after a successful move.
+type MoveVMDiskRequest struct {
+	Disk         string `json:"disk"`             // e.g. "scsi0"
+	Storage      string `json:"storage"`          // destination storage pool
+	DeleteSource *int   `json:"delete,omitempty"` // nil = omit; 1 = delete source after move
+}
+
 // APIError represents an HTTP-level error returned by the Proxmox API.
 type APIError struct {
 	StatusCode int

--- a/internal/proxmox/vms.go
+++ b/internal/proxmox/vms.go
@@ -206,3 +206,18 @@ func (c *Client) MigrateVM(ctx context.Context, node string, vmid int, req *Migr
 	}
 	return upid, nil
 }
+
+// MoveVMDisk moves a disk attached to a QEMU VM to a different storage pool.
+// It returns the UPID of the asynchronous task. If req.DeleteSource is set to 1
+// the source volume is removed after the move completes successfully.
+func (c *Client) MoveVMDisk(ctx context.Context, node string, vmid int, req *MoveVMDiskRequest) (string, error) {
+	if req == nil {
+		return "", errors.New("MoveVMDisk: req must not be nil")
+	}
+	var upid string
+	path := "/nodes/" + url.PathEscape(node) + "/qemu/" + strconv.Itoa(vmid) + "/move_disk"
+	if err := c.postWithBody(ctx, path, req, &upid); err != nil {
+		return "", fmt.Errorf("moving disk %s on VM %d on node %s: %w", req.Disk, vmid, node, err)
+	}
+	return upid, nil
+}

--- a/internal/proxmox/vms_test.go
+++ b/internal/proxmox/vms_test.go
@@ -730,3 +730,70 @@ func TestRestoreVM_apiError(t *testing.T) {
 		t.Errorf("expected *APIError, got %T: %v", err, err)
 	}
 }
+
+const testMoveVMDiskUPID = "UPID:pve1:000015E3:00000000:60F4B3A7:move_disk:100:root@pam:"
+
+func TestMoveVMDisk_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "want POST", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/nodes/pve1/qemu/100/move_disk" {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		if payload["disk"] != "scsi0" {
+			http.Error(w, "wrong disk", http.StatusBadRequest)
+			return
+		}
+		if payload["storage"] != "local-lvm" {
+			http.Error(w, "wrong storage", http.StatusBadRequest)
+			return
+		}
+		if payload["delete"] != float64(1) {
+			http.Error(w, "delete should be 1", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, testMoveVMDiskUPID))
+	}))
+	defer srv.Close()
+
+	delSrc := 1
+	req := MoveVMDiskRequest{Disk: "scsi0", Storage: "local-lvm", DeleteSource: &delSrc}
+	upid, err := newTestClient(t, srv.URL).MoveVMDisk(context.Background(), "pve1", 100, &req)
+	if err != nil {
+		t.Fatalf("MoveVMDisk: %v", err)
+	}
+	if upid != testMoveVMDiskUPID {
+		t.Errorf("upid: got %q, want %q", upid, testMoveVMDiskUPID)
+	}
+}
+
+func TestMoveVMDisk_apiError(t *testing.T) {
+	t.Parallel()
+	srv := vmErrorServer(t)
+	defer srv.Close()
+	req := MoveVMDiskRequest{Disk: "scsi0", Storage: "local-lvm"}
+	_, err := newTestClient(t, srv.URL).MoveVMDisk(context.Background(), "pve1", 100, &req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Errorf("expected *APIError, got %T: %v", err, err)
+	}
+}

--- a/tools/destructive.go
+++ b/tools/destructive.go
@@ -83,4 +83,40 @@ func registerDestructiveTools(s *mcp.Server, client *proxmox.Client) {
 		}
 		return taskResult(upid)
 	})
+
+	type nodeCommandInput struct {
+		Node      string `json:"node"      jsonschema:"name of the node (e.g. pve)"`
+		Confirmed bool   `json:"confirmed" jsonschema:"must be set to true to confirm the operation"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "reboot_node",
+		Description: "Reboot an entire Proxmox node. This takes down all VMs and containers on the node. Set confirmed=true to proceed.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: &destructiveHint,
+		},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input nodeCommandInput) (*mcp.CallToolResult, any, error) {
+		if !input.Confirmed {
+			return nil, nil, errors.New("reboot_node: confirmed must be true to proceed")
+		}
+		if err := client.NodeCommand(ctx, input.Node, "reboot"); err != nil {
+			return nil, nil, fmt.Errorf("reboot_node: %w", err)
+		}
+		return textResult("Reboot command sent to node " + input.Node)
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "shutdown_node",
+		Description: "Shut down an entire Proxmox node. This takes down all VMs and containers on the node. Set confirmed=true to proceed.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: &destructiveHint,
+		},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input nodeCommandInput) (*mcp.CallToolResult, any, error) {
+		if !input.Confirmed {
+			return nil, nil, errors.New("shutdown_node: confirmed must be true to proceed")
+		}
+		if err := client.NodeCommand(ctx, input.Node, "shutdown"); err != nil {
+			return nil, nil, fmt.Errorf("shutdown_node: %w", err)
+		}
+		return textResult("Shutdown command sent to node " + input.Node)
+	})
 }

--- a/tools/helpers.go
+++ b/tools/helpers.go
@@ -32,3 +32,12 @@ func taskResult(upid string) (*mcp.CallToolResult, any, error) {
 		},
 	}, nil, nil
 }
+
+// textResult returns a plain text MCP tool result.
+func textResult(msg string) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: msg},
+		},
+	}, nil, nil
+}

--- a/tools/vms.go
+++ b/tools/vms.go
@@ -281,4 +281,30 @@ func registerVMTools(s *mcp.Server, client *proxmox.Client) {
 		}
 		return taskResult(upid)
 	})
+
+	type moveVMDiskInput struct {
+		Node         string `json:"node"                    jsonschema:"node the VM is on"`
+		VMID         int    `json:"vmid"                    jsonschema:"numeric VM ID"`
+		Disk         string `json:"disk"                    jsonschema:"disk to move, e.g. scsi0"`
+		Storage      string `json:"storage"                 jsonschema:"destination storage pool"`
+		DeleteSource bool   `json:"delete_source,omitempty" jsonschema:"true to delete the source volume after a successful move (default false)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "move_vm_disk",
+		Description: "Move a QEMU VM disk to a different storage pool. Returns the async task ID — use get_task_status to poll for completion. Optionally set delete_source=true to remove the original volume after the move.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input moveVMDiskInput) (*mcp.CallToolResult, any, error) {
+		req := proxmox.MoveVMDiskRequest{
+			Disk:    input.Disk,
+			Storage: input.Storage,
+		}
+		if input.DeleteSource {
+			v := 1
+			req.DeleteSource = &v
+		}
+		upid, err := client.MoveVMDisk(ctx, input.Node, input.VMID, &req)
+		if err != nil {
+			return nil, nil, fmt.Errorf("move_vm_disk: %w", err)
+		}
+		return taskResult(upid)
+	})
 }


### PR DESCRIPTION
## Phase 4 PR #15 — Node power + disk move

Adds node-level power management and VM disk relocation to complete Phase 4.

### New tools

| Tool | Endpoint | Params |
|---|---|---|
| `reboot_node` | `POST /nodes/{node}/status` (`command=reboot`) | `node`, `confirmed` (must be `true`) |
| `shutdown_node` | `POST /nodes/{node}/status` (`command=shutdown`) | `node`, `confirmed` (must be `true`) |
| `move_vm_disk` | `POST /nodes/{node}/qemu/{vmid}/move_disk` | `node`, `vmid`, `disk` (e.g. `scsi0`), `storage` (target pool), `delete_source` (optional) |

### Notes
- `reboot_node` and `shutdown_node` require `PROXMOX_ALLOW_DESTRUCTIVE=true` and `confirmed=true`. Both carry `DestructiveHint: true`.
- `move_vm_disk` is always registered — data is preserved during the move. Returns a task UPID.

### Changes
- `internal/proxmox/types.go` — `NodeCommandRequest`, `MoveVMDiskRequest` structs
- `internal/proxmox/nodes.go` — `NodeCommand` client method
- `internal/proxmox/nodes_test.go` — 2 tests (success + apiError)
- `internal/proxmox/vms.go` — `MoveVMDisk` client method
- `internal/proxmox/vms_test.go` — 2 tests (success + apiError)
- `tools/destructive.go` — `reboot_node`, `shutdown_node` tool handlers
- `tools/vms.go` — `move_vm_disk` tool handler
- `tools/helpers.go` — `textResult` helper
- `README.md` — add new tools to QEMU VMs and Destructive tables
- `PLAN.md` — mark PR #15 ✅, running count 53 → 56

### Quality gate
`make check` passes: 0 lint issues, 0 security issues, 0 vulnerabilities, all tests green.