### PR TITLE
Phase 6: README installation section + PLAN.md completion status

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -7,6 +7,22 @@ Uses the official `modelcontextprotocol/go-sdk`, a custom Proxmox HTTP client (n
 Proxmox library), API token auth, and strict linting enforced via `golangci-lint`, `gosec`,
 `govulncheck`, and `go fix`.
 
+## Plan Status
+
+**Phases 1–6 complete.** All planned tools are shipped, CI and release workflows are in
+place, and the README is up to date.
+
+New phases will be added here when the next area of work is planned.
+
+| Phase | Status |
+|---|---|
+| 1 — MCP Tools (v0.1.0) | ✅ Complete |
+| 2 — Full CRUD, Snapshots, Parity (v0.2.0) | ✅ Complete |
+| 3 — Config mutation, migration, storage content, backup (v0.3.0) | ✅ Complete |
+| 4 — Restore, network visibility, node power, disk management (v0.4.0) | ✅ Complete |
+| 5 — Firewall visibility & mutation, pool management (v0.5.0) | ✅ Complete |
+| 6 — CI & Releases | ✅ Complete |
+
 ## Decisions
 
 | Decision | Choice | Rationale |
@@ -443,7 +459,7 @@ alongside `truenas-mcp` Phase 8.
 
 - [x] `ci.yml` passes on `main`
 - [x] `release.yml` produces binaries on a `v*` tag
-- [ ] README installation section complete
+- [x] README installation section complete
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -129,19 +129,35 @@ These tools are **not registered by default**. Set `PROXMOX_ALLOW_DESTRUCTIVE=tr
 
 Lifecycle and snapshot operations are non-blocking — they return the UPID of the async task immediately. Use `get_task_status` to poll for completion.
 
-## Prerequisites
+## Installation
 
-- Go 1.26+
-- A Proxmox VE cluster with API token access
-- An API token created in **Datacenter → Permissions → API Tokens**
+### Download a pre-built binary
 
-## Setup
+Download the latest release for your platform from the [Releases](https://github.com/gordcurrie/proxmox-mcp/releases) page.
+
+| Platform | Binary |
+|---|---|
+| Linux (amd64) | `proxmox-mcp_linux_amd64` |
+| Linux (ARM64) | `proxmox-mcp_linux_arm64` |
+| macOS (Intel) | `proxmox-mcp_darwin_amd64` |
+| macOS (Apple Silicon) | `proxmox-mcp_darwin_arm64` |
+| Windows | `proxmox-mcp_windows_amd64.exe` |
+
+Make it executable and place it on your `PATH`:
+
+```bash
+chmod +x proxmox-mcp_linux_amd64
+mv proxmox-mcp_linux_amd64 /usr/local/bin/proxmox-mcp
+```
+
+### Build from source
+
+Requires Go 1.26+. You will also need a Proxmox VE API token — create one in **Datacenter → Permissions → API Tokens**.
 
 ```bash
 git clone https://github.com/gordcurrie/proxmox-mcp
 cd proxmox-mcp
-cp .env.example .env   # then edit .env with your credentials
-make build             # binary lands in bin/proxmox-mcp
+make build   # binary lands in bin/proxmox-mcp
 ```
 
 ## Configuration
@@ -246,7 +262,7 @@ Add the server to `opencode.json` in your project root (or `~/.config/opencode/o
 ```bash
 make install-tools   # install golangci-lint, gosec, govulncheck, gofumpt
 make check           # full quality gate: fix, fmt, vet, lint, sec, vulncheck, test, build
-make test            # tests only
+make test            # tests only (with race detector)
 make build           # build only → bin/proxmox-mcp
 make clean           # remove bin/
 ```

--- a/README.md
+++ b/README.md
@@ -138,17 +138,19 @@ Download the latest release for your platform from the [Releases](https://github
 | Platform | Binary |
 |---|---|
 | Linux (amd64) | `proxmox-mcp_linux_amd64` |
-| Linux (ARM64) | `proxmox-mcp_linux_arm64` |
-| macOS (Intel) | `proxmox-mcp_darwin_amd64` |
-| macOS (Apple Silicon) | `proxmox-mcp_darwin_arm64` |
-| Windows | `proxmox-mcp_windows_amd64.exe` |
+| Linux (arm64) | `proxmox-mcp_linux_arm64` |
+| macOS (amd64) | `proxmox-mcp_darwin_amd64` |
+| macOS (arm64) | `proxmox-mcp_darwin_arm64` |
+| Windows (amd64) | `proxmox-mcp_windows_amd64.exe` |
 
-Make it executable and place it on your `PATH`:
+Make it executable and place it on your `PATH` (substitute the filename for your platform):
 
 ```bash
-chmod +x proxmox-mcp_linux_amd64
-mv proxmox-mcp_linux_amd64 /usr/local/bin/proxmox-mcp
+chmod +x <binary-name>
+mv <binary-name> /usr/local/bin/proxmox-mcp
 ```
+
+> Windows users: rename the `.exe` and add it to a directory on your `%PATH%`.
 
 ### Build from source
 
@@ -157,7 +159,9 @@ Requires Go 1.26+. You will also need a Proxmox VE API token — create one in *
 ```bash
 git clone https://github.com/gordcurrie/proxmox-mcp
 cd proxmox-mcp
-make build   # binary lands in bin/proxmox-mcp
+cp .env.example .env   # copy the example env file
+$EDITOR .env           # set PROXMOX_* values (see table below)
+make build             # binary lands in bin/proxmox-mcp
 ```
 
 ## Configuration
@@ -264,5 +268,5 @@ make install-tools   # install golangci-lint, gosec, govulncheck, gofumpt
 make check           # full quality gate: fix, fmt, vet, lint, sec, vulncheck, test, build
 make test            # tests only (with race detector)
 make build           # build only → bin/proxmox-mcp
-make clean           # remove bin/
+make clean           # remove bin/proxmox-mcp
 ```


### PR DESCRIPTION
## Phase 6 final: README installation section + PLAN.md completion\n\n### README changes\n\n- **Installation section added**: replaces the old `Prerequisites` + `Setup` sections\n  - Binary download table for all 5 release platforms with `chmod`/`mv` instructions\n  - Build from source instructions (Go 1.26+ prerequisite moved here)\n- **Development section**: added `(with race detector)` note to `make test` line for consistency with truenas-mcp\n\n### PLAN.md changes\n\n- Added **Plan Status** section with phase completion table (Phases 1–6 all ✅)\n- Notes that new phases will be added when the next area of work is planned