### PR TITLE
feat: Phase 7 — storage definition management (5 new tools)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -102,10 +102,10 @@ New `AddStorageRequest` and `UpdateStorageRequest` structs in `types.go`. Fields
 | Tool | API endpoint | Params |
 |---|---|---|
 | `add_storage` | `POST /storage` | `storage` (name), `type` (`nfs`\|`pbs`\|`dir`\|`cifs`\|`zfspool`), `server` (optional), `export` (optional, NFS export path), `path` (optional, dir/local path), `datastore` (optional, PBS datastore name), `username` (optional, PBS/CIFS user), `password` (optional, PBS/CIFS), `content` (optional e.g. `backup,images`), `nodes` (optional, comma-sep to restrict to specific nodes) |
-| `update_storage` | `PUT /storage/{storage}` | `storage`, plus any subset of the add params |
+| `update_storage` | `PUT /storage/{storage}` | `storage` (name, identifier only — type cannot be changed), `server` (optional), `export` (optional), `path` (optional), `datastore` (optional), `username` (optional), `password` (optional), `fingerprint` (optional), `content` (optional), `nodes` (optional), `shared` (optional) |
 | `remove_storage` | `DELETE /storage/{storage}` | `storage`, `confirmed: true` — destructive opt-in |
 
-Tests: success + apiError for add/update; success + notFound for remove (6 new tests).
+Tests: success + apiError for add/update; success + notFound for remove.
 
 **Phase 7 target tool count:** 71 + 5 = **76 tools** (70 always-on + 6 destructive opt-in).
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,87 +2,38 @@
 
 ## Summary
 
-Build an MCP server in Go that exposes Proxmox VE cluster operations as MCP tools.
-Uses the official `modelcontextprotocol/go-sdk`, a custom Proxmox HTTP client (no third-party
-Proxmox library), API token auth, and strict linting enforced via `golangci-lint`, `gosec`,
-`govulncheck`, and `go fix`.
+Go MCP server exposing Proxmox VE cluster operations as tools. Uses `modelcontextprotocol/go-sdk`,
+a custom `net/http` Proxmox client (no third-party Proxmox library), API token auth, and strict
+linting via `golangci-lint`/`gosec`/`govulncheck`.
 
 ## Plan Status
 
-**Phases 1–6 complete.** All planned tools are shipped, CI and release workflows are in
-place, and the README is up to date.
-
-New phases will be added here when the next area of work is planned.
-
 | Phase | Status |
 |---|---|
-| 1 — MCP Tools (v0.1.0) | ✅ Complete |
-| 2 — Full CRUD, Snapshots, Parity (v0.2.0) | ✅ Complete |
-| 3 — Config mutation, migration, storage content, backup (v0.3.0) | ✅ Complete |
-| 4 — Restore, network visibility, node power, disk management (v0.4.0) | ✅ Complete |
-| 5 — Firewall visibility & mutation, pool management (v0.5.0) | ✅ Complete |
-| 6 — CI & Releases | ✅ Complete |
+| 1–6 (Foundation through CI & Releases) | ✅ Complete — 71 tools shipped (v0.6.0) |
+| 7 — Storage Management | ✅ Complete — 76 tools (v0.7.0) |
 
 ## Decisions
 
 | Decision | Choice | Rationale |
 |---|---|---|
 | MCP SDK | `github.com/modelcontextprotocol/go-sdk` | Official Go SDK |
-| Proxmox client | Custom `net/http` wrapper | Full control, no external dep, easy to extend |
+| Proxmox client | Custom `net/http` wrapper | Full control, no external dep |
 | Auth | API token only (`PVEAPIToken=`) | Stateless, no CSRF, no ticket renewal |
-| Transports | Both stdio + HTTP (flag-selected) | stdio for local clients, HTTP for remote/shared |
-| Linter | `golangci-lint` + `gosec` + `govulncheck` | Security-first, idiomatic Go |
-| Formatter | `gofumpt` (stricter than `gofmt`) | Consistent style |
-| TLS | `PROXMOX_INSECURE=true` opt-in for skip-verify | Proxmox uses self-signed certs by default |
-| Error handling | Always wrap with `fmt.Errorf("doing X: %w", err)` | Idiomatic, stack-traceable |
-| Global state | None — client injected, no `init()` | Testable, explicit |
-
-## Project Structure
-
-```
-proxmox_mcp/
-├── cmd/
-│   └── proxmox-mcp/
-│       └── main.go           # entrypoint, CLI flags, transport selection
-├── internal/
-│   └── proxmox/
-│       ├── client.go         # custom HTTP client (auth, TLS, base URL)
-│       ├── client_test.go    # httptest-based unit tests
-│       ├── types.go          # shared Proxmox response/request structs
-│       ├── cluster.go        # cluster-wide API calls
-│       ├── nodes.go          # node-related API calls
-│       ├── vms.go            # QEMU VM API calls
-│       ├── containers.go     # LXC container API calls
-│       ├── snapshots.go      # snapshot API calls
-│       ├── tasks.go          # task polling (UPID → status)
-│       ├── storage.go        # storage content API calls (Phase 3)
-│       └── backup.go         # backup/vzdump API calls (Phase 3)
-├── tools/
-│   ├── register.go           # RegisterAll(cfg Config) wires all tools onto the MCP server
-│   ├── cluster.go            # cluster-wide MCP tools
-│   ├── nodes.go              # node MCP tools
-│   ├── vms.go                # VM MCP tools
-│   ├── containers.go         # container MCP tools
-│   ├── snapshots.go          # snapshot MCP tools
-│   ├── destructive.go        # delete_vm, delete_container (opt-in via Config.AllowDestructive)
-│   ├── storage.go            # storage content MCP tools (Phase 3)
-│   └── backup.go             # backup MCP tools (Phase 3)
-├── .golangci.yml             # linter config
-├── Makefile                  # quality gate targets
-├── go.mod
-├── go.sum
-└── PLAN.md                   # this file
-```
+| Transports | stdio (default) + HTTP (`--transport=http`) | stdio for local clients, HTTP for remote |
+| Formatter | `gofumpt` | Stricter than `gofmt` |
+| TLS | Verify on by default; `PROXMOX_INSECURE=true` to skip | Proxmox uses self-signed certs by default |
+| Destructive tools | Opt-in via `PROXMOX_ALLOW_DESTRUCTIVE=true` | Safe by default |
 
 ## Environment Variables
 
 | Variable | Required | Description |
 |---|---|---|
-| `PROXMOX_API_URL` | yes | Base URL, e.g. `https://pve:8006/api2/json` |
-| `PROXMOX_TOKEN_ID` | yes | Token ID, e.g. `root@pam!mcp` |
+| `PROXMOX_API_URL` | yes | e.g. `https://pve:8006/api2/json` |
+| `PROXMOX_TOKEN_ID` | yes | e.g. `root@pam!mcp` |
 | `PROXMOX_TOKEN_SECRET` | yes | Token UUID secret |
-| `PROXMOX_INSECURE` | no | Set `true` to skip TLS verification (self-signed certs) |
-| `PROXMOX_ALLOW_DESTRUCTIVE` | no | Set `true` to register `delete_vm` and `delete_container` tools (default: disabled) |
+| `PROXMOX_INSECURE` | no | `true` to skip TLS verification |
+| `PROXMOX_ALLOW_DESTRUCTIVE` | no | `true` to register destructive tools |
 
 ## CLI Flags
 
@@ -93,373 +44,73 @@ proxmox_mcp/
 
 ## Makefile Targets
 
-| Target | What it does |
-|---|---|
-| `make install-tools` | Installs `golangci-lint`, `gosec`, `govulncheck` |
-| `make fmt` | `gofumpt -w .` |
-| `make fix` | `go fix ./...` |
-| `make vet` | `go vet ./...` |
-| `make lint` | `golangci-lint run ./...` |
-| `make sec` | `gosec ./...` (standalone) |
-| `make vulncheck` | `govulncheck ./...` |
-| `make test` | `go test -race -count=1 ./...` |
-| `make build` | `go build ./cmd/proxmox-mcp/` |
-| `make check` | **All of the above in order** — pre-commit gate |
+`make fix` → `make fmt` → `make vet` → `make lint` → `make sec` → `make vulncheck` →
+`make test` → `make build` — all run by `make check`.
 
-## Linters Enabled (golangci-lint)
+## Linters Enabled
 
-- `gosec` — hardcoded creds, TLS misconfig, weak crypto
-- `govet` — struct alignment, printf mismatches
-- `staticcheck` — broad static analysis
-- `errcheck` — no silently dropped errors
-- `ineffassign` — catch useless assignments
-- `unused` — dead code
-- `bodyclose` — HTTP response bodies must be closed
-- `noctx` — HTTP requests must use context
-- `gocritic` — opinionated style checks
-- `revive` — drop-in `golint` replacement
-- `misspell` — typos in comments/strings
-- `prealloc` — slice preallocation hints
-- `unconvert` — unnecessary type conversions
-- `unparam` — unused function parameters
-- `gofumpt` — formatting
+`gosec`, `govet`, `staticcheck`, `errcheck`, `bodyclose`, `noctx`, `gofumpt`, `revive`,
+`gocritic`, `unparam`, `unconvert`, `misspell`, `prealloc`, `ineffassign`, `unused`.
 
-`InsecureSkipVerify` usage annotated with `//nolint:gosec // G402: user explicitly opted in via PROXMOX_INSECURE=true`.
-
-## Phase 1 MCP Tools (v0.1.0 — shipped)
-
-| Tool | Description | Params |
-|---|---|---|
-| `list_nodes` | List all nodes in the cluster | — |
-| `get_node_status` | Detailed status of a node | `node` |
-| `list_cluster_resources` | All resources across cluster | `type` (optional: vm, storage, node, sdn) |
-| `get_task_status` | Poll a Proxmox async task by UPID | `node`, `upid` |
-| `list_vms` | QEMU VMs on a node | `node` |
-| `get_vm_status` | VM status + current config | `node`, `vmid` |
-| `start_vm` | Start a VM | `node`, `vmid` |
-| `stop_vm` | Hard stop a VM | `node`, `vmid` |
-| `shutdown_vm` | Graceful shutdown of a VM | `node`, `vmid` |
-| `list_containers` | LXC containers on a node | `node` |
-| `get_container_status` | Container status | `node`, `vmid` |
-| `start_container` | Start a container | `node`, `vmid` |
-| `stop_container` | Stop a container | `node`, `vmid` |
-
-Lifecycle operations return task info immediately (non-blocking). Task status can be checked
-separately.
+`InsecureSkipVerify` annotated with `//nolint:gosec // G402: user explicitly opted in via PROXMOX_INSECURE=true`.
 
 ---
 
-## Phase 2 — Full CRUD, Snapshots, Parity, Depth ✅ shipped (v0.2.0)
+## Phase 7 — Storage Management (target: v0.7.0)
 
-6 PRs merged (#2–#7). Final tool count: **38 tools**.
+**Goal**: Allow agents to register and manage storage targets cluster-wide — required for
+the Proxmox Backup Server (PBS) integration with TrueNAS and for NFS-based backup storage.
 
-| PR | Tools added | Key changes |
-|---|---|---|
-| #2 — client foundations | — | `postWithBody`, `delete`, `put` in `client.go` |
-| #3 — lifecycle parity | `reboot_vm`, `suspend_vm`, `resume_vm`, `shutdown_container`, `reboot_container` | uses `post()` |
-| #4 — snapshots | `list/create/rollback/delete` × VM + container (8 tools) | `snapshots.go`, `tools/snapshots.go` |
-| #5 — delete operations | `delete_vm`, `delete_container` | `tools/destructive.go`; 3-layer safety gate; `PROXMOX_ALLOW_DESTRUCTIVE` env var |
-| #6 — create & clone | `create_vm`, `clone_vm`, `create_container`, `clone_container` | `SensitiveString` type for password redaction |
-| #7 — node/cluster depth | `get_cluster_status`, `list_node_storage`, `list_node_tasks`, `get_node_disks`, `get_vm_config`, `get_container_config` | read-only; no new HTTP primitives |
+Proxmox storage definitions are cluster-wide (not per-node). They live under `/storage` and
+support many types: `nfs`, `pbs`, `dir`, `cifs`, `zfspool`, etc. `type=pbs` is the key
+integration point for pointing Proxmox at a PBS instance running on TrueNAS SCALE.
 
----
+### End-to-end PBS + TrueNAS workflow (enabled by this phase)
 
-## Phase 3 — Config mutation, migration, storage content, backup ✅ shipped (v0.3.0)
+1. **TrueNAS** `create_dataset` — create the PBS datastore path (e.g. `tank/pbs-datastore`)
+2. **TrueNAS** `install_custom_app` — deploy PBS as a Docker Compose app, mounting the dataset
+3. **Proxmox** `add_storage` *(this phase)* — register `type=pbs` pointing at TrueNAS IP:8007
+4. **Proxmox** `create_backup` *(exists)* — run backups to the PBS storage
 
-Builds on the `put` and `postWithBody` client methods already in place from Phase 2 PR #2.
-Delivered across 5 PRs (#8–#12). Final tool count: **49 tools** (46 always-on + 3 destructive opt-in).
+**NFS fallback**: replace steps 2–3 with TrueNAS `create_nfs_share` (truenas-mcp Phase 10)
+and Proxmox `add_storage` with `type=nfs`.
 
-### PR #8 — Config mutation (4 new tools)
+New file `internal/proxmox/storagedef.go` (separate from the existing `storage.go`, which
+handles per-node storage *content*). New file `tools/storagedef.go`. `RegisterAll` gains
+`registerStorageDefTools`.
 
-Uses the existing `put()` client method — no new HTTP primitives needed.
-Proxmox exposes a sync (`PUT`) and async (`POST`) variant for config; we use `PUT` here so
-the result is immediate and no task polling is required.
+### PR #20 — Storage definition read-only (2 new tools) ✅
 
-New request structs `SetVMConfigRequest` and `SetContainerConfigRequest` in `types.go`.
-Both expose a focused, safe subset of mutable fields — not a free-form map — to prevent
-accidental misconfiguration. Fields use `omitempty` so callers only send what they intend to
-change. Client methods take request structs by pointer (gocritic `hugeParam`).
-
-Resize operations use a separate `PUT` endpoint that takes `disk` + `size` params; they
-return a task UPID (async). New `ResizeDiskRequest` struct.
+Both get `ReadOnlyHint: true`. Tests: success + notFound for each (4 new tests).
 
 | Tool | API endpoint | Params |
 |---|---|---|
-| `set_vm_config` | `PUT /nodes/{node}/qemu/{vmid}/config` | `node`, `vmid`, `memory`, `cores`, `name`, `onboot`, `description` |
-| `set_container_config` | `PUT /nodes/{node}/lxc/{vmid}/config` | `node`, `vmid`, `memory`, `swap`, `hostname`, `onboot`, `description` |
-| `resize_vm_disk` | `PUT /nodes/{node}/qemu/{vmid}/resize` | `node`, `vmid`, `disk` (e.g. `scsi0`), `size` (e.g. `+10G` or `50G`) |
-| `resize_container_disk` | `PUT /nodes/{node}/lxc/{vmid}/resize` | `node`, `vmid`, `disk` (e.g. `rootfs`), `size` |
+| `list_storages` | `GET /storage` | `type` (optional filter: `nfs`, `pbs`, `dir`, `cifs`, `zfspool`, etc.) |
+| `get_storage` | `GET /storage/{storage}` | `storage` (name) |
 
-`resize_vm_disk` and `resize_container_disk` return task UPIDs — use `get_task_status` to
-poll for completion.
+### PR #21 — Storage definition write (3 new tools) ✅
 
-Tests: success + apiError for all four client methods (8 new tests). `set_vm_config` and
-`set_container_config` additionally test that `omitempty` fields are omitted from the request
-body.
+`add_storage` uses `postWithBody`, `update_storage` uses `put`, `remove_storage` uses
+`delete` — no new HTTP primitives needed.
 
-### PR #9 — Migration (2 new tools)
+`remove_storage` follows the 3-layer safety pattern (`PROXMOX_ALLOW_DESTRUCTIVE` +
+`confirmed: true` + `DestructiveHint`).
 
-Uses existing `postWithBody` — no new HTTP primitives needed.
-Both tools return a task UPID immediately (non-blocking).
-
-New `MigrateVMRequest` and `MigrateContainerRequest` structs in `types.go`. Client methods
-in `vms.go` and `containers.go` respectively.
+New `AddStorageRequest` and `UpdateStorageRequest` structs in `types.go`. Fields use
+`omitempty` so only set fields are sent.
 
 | Tool | API endpoint | Params |
 |---|---|---|
-| `migrate_vm` | `POST /nodes/{node}/qemu/{vmid}/migrate` | `node`, `vmid`, `target` (destination node), `online` (bool, live migrate) |
-| `migrate_container` | `POST /nodes/{node}/lxc/{vmid}/migrate` | `node`, `vmid`, `target`, `restart` (bool) |
+| `add_storage` | `POST /storage` | `storage` (name), `type` (`nfs`\|`pbs`\|`dir`\|`cifs`\|`zfspool`), `server` (optional), `export` (optional, NFS export path), `path` (optional, dir/local path), `datastore` (optional, PBS datastore name), `username` (optional, PBS/CIFS user), `password` (optional, PBS/CIFS), `content` (optional e.g. `backup,images`), `nodes` (optional, comma-sep to restrict to specific nodes) |
+| `update_storage` | `PUT /storage/{storage}` | `storage`, plus any subset of the add params |
+| `remove_storage` | `DELETE /storage/{storage}` | `storage`, `confirmed: true` — destructive opt-in |
 
-`online: true` performs a live migration for VMs (no guest downtime when supported).
-`restart: true` for containers stops, migrates, and restarts the container on the target node.
+Tests: success + apiError for add/update; success + notFound for remove (6 new tests).
 
-Tests: success + apiError for both client methods (4 new tests).
+**Phase 7 target tool count:** 71 + 5 = **76 tools** (70 always-on + 6 destructive opt-in).
 
-### PR #10 — Storage content (3 new tools)
-
-Uses existing `get()` for listing and the existing `delete()` method for removal.
-New file `internal/proxmox/storage.go`. New file `tools/storage.go`.
-`RegisterAll` gains `registerStorageTools`.
-
-`delete_storage_content` is gated behind `PROXMOX_ALLOW_DESTRUCTIVE` and follows the same
-3-layer safety pattern as `delete_vm`/`delete_container` (operator env var + `confirmed`
-field + `DestructiveHint`).
-
-| Tool | API endpoint | Params |
-|---|---|---|
-| `list_storage_content` | `GET /nodes/{node}/storage/{storage}/content` | `node`, `storage`, `content` (optional filter: `iso`, `vztmpl`, `backup`, `images`) |
-| `get_storage_content_info` | `GET /nodes/{node}/storage/{storage}/content/{volume}` | `node`, `storage`, `volume` (volid, e.g. `local:iso/debian.iso`) |
-| `delete_storage_content` | `DELETE /nodes/{node}/storage/{storage}/content/{volume}` | `node`, `storage`, `volume`, `confirmed` (must be `true`) |
-
-`list_storage_content` is the primary discovery tool for ISOs and container templates —
-needed to populate valid values for `create_vm` and `create_container`.
-
-Tests: success + notFound for `list_storage_content` and `get_storage_content_info`;
-success + apiError for `delete_storage_content` (5 new tests).
-
-### PR #11 — Backup (2 new tools)
-
-Uses existing `postWithBody` and `get()` — no new HTTP primitives needed.
-New `CreateBackupRequest` struct in `types.go`. Client methods in a new
-`internal/proxmox/backup.go`. New `tools/backup.go`. `RegisterAll` gains
-`registerBackupTools`.
-
-`create_backup` is async — returns a task UPID to poll with `get_task_status`.
-`list_backups` is a convenience wrapper around `list_storage_content` filtered to
-`content=backup`; it can be implemented as a dedicated client method or by reusing the
-storage content client from PR 9.
-
-| Tool | API endpoint | Params |
-|---|---|---|
-| `create_backup` | `POST /nodes/{node}/vzdump` | `node`, `vmid`, `storage`, `mode` (`snapshot`/`suspend`/`stop`, default `snapshot`), `compress` (`0`/`gzip`/`lzo`/`zstd`, default `zstd`) |
-| `list_backups` | `GET /nodes/{node}/storage/{storage}/content?content=backup` | `node`, `storage` |
-
-`mode: snapshot` is the preferred default — no guest downtime for VMs with QEMU guest agent.
-`compress: zstd` gives the best speed/ratio trade-off on modern hardware.
-
-Tests: success + apiError for `create_backup`; success + notFound for `list_backups`
-(4 new tests).
-
-### PR #12 — MCP annotations + documentation
-
-`ReadOnlyHint: true` added to all 19 read-only tools across 7 `tools/` files.
-README updated with configuration examples for VS Code Copilot, Claude Desktop, and OpenCode.
-Generic placeholders used for all hostnames and token IDs in config examples.
-
----
-
-## CI — GitHub Actions ✅ in place
-
-`.github/workflows/ci.yml` runs on every push and PR to `main`, split across two jobs:
-
-| Job | Steps |
-|---|---|
-| `test` | `go test -race -count=1 ./...` |
-| `lint` | `make install-tools` → `fix` → `fmt` → `vet` → `golangci-lint` → `gosec` → `govulncheck` → `build` |
-
----
-
-## Phase 4 — Restore, network visibility, node power, disk management (target: v0.4.0)
-
-Completes the operational lifecycle gaps identified after v0.3.0. Delivered across 3 PRs.
-Each must pass `make check` before merge.
-
-### PR #13 — Backup restore (2 new tools) ✅
-
-Completes the backup lifecycle: create → list → **restore** → delete.
-Uses existing `postWithBody` — same HTTP primitive as `create_vm` / `create_container`.
-Restore is the same `POST /nodes/{node}/qemu` and `POST /nodes/{node}/lxc` endpoints as
-create, but with an `archive=` parameter pointing to a backup volume ID instead of building
-a fresh VM config.
-
-New `RestoreVMRequest` and `RestoreContainerRequest` structs in `types.go`.
-New client methods `RestoreVM` in `vms.go`, `RestoreContainer` in `containers.go`.
-Tool handlers in `tools/vms.go` and `tools/containers.go` respectively.
-
-| Tool | API endpoint | Params |
-|---|---|---|
-| `restore_vm` | `POST /nodes/{node}/qemu` w/ `archive=` | `node`, `vmid` (target ID), `archive` (volid e.g. `local:backup/vzdump-qemu-100-...tar.zst`), `storage` (target storage), `start` (bool) |
-| `restore_container` | `POST /nodes/{node}/lxc` w/ `ostemplate=` | `node`, `vmid` (target ID), `archive` (volid), `storage` (target rootfs storage), `hostname`, `start` (bool) |
-
-Both return a task UPID — poll with `get_task_status`.
-
-Tests: success + apiError for both client methods (4 new tests).
-
-### PR #14 — Node network (2 new tools) ✅
-
-Read-only tools to inspect node networking — required context before creating VMs or
-containers that need specific bridges. Both get `ReadOnlyHint: true`.
-
-New file `internal/proxmox/network.go`. New file `tools/network.go`.
-`RegisterAll` gains `registerNetworkTools`.
-
-| Tool | API endpoint | Params |
-|---|---|---|
-| `list_node_network` | `GET /nodes/{node}/network` | `node`, `type` (optional filter: `bridge`, `bond`, `eth`, `alias`, `vlan`, `OVSBridge`, `OVSBond`, `OVSPort`, `OVSIntPort`, `any_bridge`) |
-| `get_node_network_interface` | `GET /nodes/{node}/network/{iface}` | `node`, `iface` (interface name e.g. `vmbr0`) |
-
-Tests: success + notFound for each (4 new tests).
-
-### PR #15 — Node power + disk move (3 new tools) ✅
-
-Node-level power management and VM disk relocation. Two distinct API areas bundled because
-both are small and share the same PR quality overhead.
-
-**Node power** — `POST /nodes/{node}/status` with `command=reboot|shutdown`. These are
-destructive by nature (take down a whole node) so both require `confirmed: true` and are
-gated behind `PROXMOX_ALLOW_DESTRUCTIVE`. Client method `NodeCommand(ctx, node, command)`
-in `nodes.go`. Tool handlers in `tools/nodes.go`.
-
-**Move VM disk** — `POST /nodes/{node}/qemu/{vmid}/move_disk`. Moves a VM disk to a
-different storage pool; optionally deletes the source after move. Returns a task UPID.
-New `MoveVMDiskRequest` struct in `types.go`. Client method `MoveVMDisk` in `vms.go`.
-Tool handler in `tools/vms.go`.
-
-| Tool | API endpoint | Params |
-|---|---|---|
-| `reboot_node` | `POST /nodes/{node}/status` (`command=reboot`) | `node`, `confirmed` (must be `true`) |
-| `shutdown_node` | `POST /nodes/{node}/status` (`command=shutdown`) | `node`, `confirmed` (must be `true`) |
-| `move_vm_disk` | `POST /nodes/{node}/qemu/{vmid}/move_disk` | `node`, `vmid`, `disk` (e.g. `scsi0`), `storage` (target storage), `delete_source` (bool, default `false`) |
-
-`reboot_node` and `shutdown_node` use `DestructiveHint: true` and are only registered when
-`PROXMOX_ALLOW_DESTRUCTIVE=true`. `move_vm_disk` is always registered (non-destructive —
-data is preserved).
-
-Tests: success + apiError for all three (6 new tests).
-
-**Phase 4 target tool count:** 49 + 7 = **56 tools** (51 always-on + 5 destructive opt-in).
-Running total after PR #13: **51 tools** (48 always-on + 3 destructive opt-in).
-Running total after PR #14: **53 tools** (50 always-on + 3 destructive opt-in).
-Running total after PR #15: **56 tools** (51 always-on + 5 destructive opt-in).
-
----
-
-## Phase 5 — Firewall visibility & mutation, pool management (target: v0.5.0)
-
-Adds security policy inspection and mutation across all resource levels, plus cluster pool
-CRUD to round out resource organisation. Delivered across 3 PRs.
-
-### PR #17 — Firewall read-only (all levels) ✅
-
-Six read-only tools covering the three firewall scopes Proxmox exposes: cluster (datacenter),
-per-VM, and per-container. All get `ReadOnlyHint: true`. No new HTTP primitives — all use
-the existing `get()` client method.
-
-New file `internal/proxmox/firewall.go`. New file `tools/firewall.go`.
-`RegisterAll` gains `registerFirewallTools`.
-
-| Tool | API endpoint | Params |
-|---|---|---|
-| `list_cluster_firewall_rules` | `GET /cluster/firewall/rules` | — |
-| `get_cluster_firewall_options` | `GET /cluster/firewall/options` | — |
-| `list_vm_firewall_rules` | `GET /nodes/{node}/qemu/{vmid}/firewall/rules` | `node`, `vmid` |
-| `get_vm_firewall_options` | `GET /nodes/{node}/qemu/{vmid}/firewall/options` | `node`, `vmid` |
-| `list_container_firewall_rules` | `GET /nodes/{node}/lxc/{vmid}/firewall/rules` | `node`, `vmid` |
-| `get_container_firewall_options` | `GET /nodes/{node}/lxc/{vmid}/firewall/options` | `node`, `vmid` |
-
-Tests: success + notFound for each (12 new tests).
-
-### PR #18 — Firewall write (VM + container rule mutation) ✅
-
-Adds and removes per-VM and per-container firewall rules. Uses existing `postWithBody` for
-add and `delete` for remove. Rules are addressed by zero-based position (`pos`) for deletion.
-
-New `FirewallRuleRequest` struct in `types.go` with full Proxmox rule fields: `type`
-(in/out), `action` (ACCEPT/DROP/REJECT), `enable`, `iface`, `source`, `dest`, `proto`,
-`dport`, `sport`, `comment`. Fields use `omitempty` — only set fields are sent.
-
-`delete_vm_firewall_rule` and `delete_container_firewall_rule` are not gated behind
-`PROXMOX_ALLOW_DESTRUCTIVE` — individual rule deletion is low-risk and reversible.
-
-| Tool | API endpoint | Params |
-|---|---|---|
-| `add_vm_firewall_rule` | `POST /nodes/{node}/qemu/{vmid}/firewall/rules` | `node`, `vmid`, `type`, `action`, `enable`, `iface`, `source`, `dest`, `proto`, `dport`, `sport`, `comment` |
-| `delete_vm_firewall_rule` | `DELETE /nodes/{node}/qemu/{vmid}/firewall/rules/{pos}` | `node`, `vmid`, `pos` |
-| `add_container_firewall_rule` | `POST /nodes/{node}/lxc/{vmid}/firewall/rules` | `node`, `vmid`, `type`, `action`, `enable`, `iface`, `source`, `dest`, `proto`, `dport`, `sport`, `comment` |
-| `delete_container_firewall_rule` | `DELETE /nodes/{node}/lxc/{vmid}/firewall/rules/{pos}` | `node`, `vmid`, `pos` |
-
-Tests: success + apiError for add; success + notFound for delete (8 new tests).
-
-### PR #19 — Pool management
-
-Cluster resource pools group VMs and storage for access control and organisation. Four
-always-on tools plus one destructive opt-in. All use existing HTTP primitives.
-
-New file `internal/proxmox/pools.go`. Pool tools added to a new `tools/pools.go`.
-`RegisterAll` gains `registerPoolTools`.
-
-`delete_pool` follows the same 3-layer safety pattern as `delete_vm` (env var +
-`confirmed: true` + `DestructiveHint: true`), registered only when
-`PROXMOX_ALLOW_DESTRUCTIVE=true`.
-
-`update_pool` uses `PUT /cluster/pools/{poolid}` and supports adding/removing VMs and
-storage from the pool via comma-separated ID lists. Set `delete: true` in the request to
-remove the listed members instead of adding them.
-
-| Tool | API endpoint | Params |
-|---|---|---|
-| `list_pools` | `GET /cluster/pools` | — |
-| `get_pool` | `GET /cluster/pools/{poolid}` | `poolid` |
-| `create_pool` | `POST /cluster/pools` | `poolid`, `comment` (optional) |
-| `update_pool` | `PUT /cluster/pools/{poolid}` | `poolid`, `comment`, `vms` (comma-sep vmids), `storage` (comma-sep), `delete` (bool — remove listed members instead of add) |
-| `delete_pool` | `DELETE /cluster/pools/{poolid}` | `poolid`, `confirmed` (must be `true`) |
-
-Tests: success + notFound for list/get; success + apiError for create/update/delete
-(10 new tests).
-
-**Phase 5 target tool count:** 56 + 15 = **71 tools** (65 always-on + 6 destructive opt-in).
-Running total after PR #17: **62 tools** (57 always-on + 5 destructive opt-in). ✅
-Running total after PR #18: **66 tools** (61 always-on + 5 destructive opt-in). ✅
-Running total after PR #19: **71 tools** (65 always-on + 6 destructive opt-in). ✅
-
----
-
-## Phase 6 — CI & Releases
-
-Prerequisite: all feature phases merged and repo made public. To be implemented
-alongside `truenas-mcp` Phase 8.
-
-### GitHub Actions Workflows
-
-**`.github/workflows/ci.yml`** — runs on every push and PR to `main`:
-- `make check` (fix, fmt, vet, lint, sec, vulncheck, test -race, build)
-
-**`.github/workflows/release.yml`** — runs on `v*` tag push:
-- Cross-compile for: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`
-- Upload binaries to GitHub Release
-- Binary naming convention: `proxmox-mcp_<os>_<arch>[.exe]`
-
-### README Updates
-
-- Add **Installation** section: download binary from Releases page
-- Add **VS Code `mcp.json`** usage snippet with env var instructions
-- Add **Building from source** section for Go users
-
-### Definition of Done
-
-- [x] `ci.yml` passes on `main`
-- [x] `release.yml` produces binaries on a `v*` tag
-- [x] README installation section complete
+Running total after PR #20: **73 tools** (68 always-on + 5 destructive).
+Running total after PR #21: **76 tools** (70 always-on + 6 destructive).
 
 ---
 
@@ -467,31 +118,7 @@ alongside `truenas-mcp` Phase 8.
 
 - Base URL: `https://<host>:8006/api2/json`
 - All responses wrapped in `{"data": ...}` — unwrapped transparently by the client
-- Many write operations (create, clone, migrate) are async — they return a UPID task ID;
+- Many write operations are async — they return a UPID task ID;
   poll `/nodes/{node}/tasks/{upid}/status` for completion
 - API token format: `Authorization: PVEAPIToken=USER@REALM!TOKENID=UUID`
 - No CSRF token needed when using API tokens
-- `GET /version` — good health-check endpoint
-
-## Idiomatic Go Standards
-
-- Error wrapping: `fmt.Errorf("listing VMs on node %s: %w", node, err)`
-- Sentinel errors: `var ErrNotFound = errors.New("resource not found")`
-- Pointer receivers on `Client` and mutable types
-- Value receivers on small read-only structs
-- `context.Context` first param on all I/O functions
-- Exported types and functions always have doc comments
-- `json` + `jsonschema` struct tags on all API types and MCP input structs
-- Table-driven tests with `t.Run` subtests
-- No `init()` anywhere
-
-## Implementation Order
-
-1. `go.mod`, `Makefile`, `.golangci.yml`
-2. `internal/proxmox/types.go` — structs
-3. `internal/proxmox/client.go` — HTTP client
-4. `internal/proxmox/client_test.go` — client unit tests
-5. `internal/proxmox/{nodes,vms,containers,tasks}.go` — API methods
-6. `tools/{register,nodes,vms,containers,cluster}.go` — MCP tools
-7. `cmd/proxmox-mcp/main.go` — entrypoint
-8. `make check` — all gates pass

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 | `list_storage_content` | List volumes in a storage pool | `node`, `storage`, `content` (optional: `iso`, `vztmpl`, `backup`, `images`) |
 | `get_storage_content_info` | Detailed info about a specific volume | `node`, `storage`, `volume` (full volid, e.g. `local:iso/debian.iso`) |
 
+### Storage Definitions
+
+| Tool | Description | Parameters |
+|---|---|---|
+| `list_storages` | List all cluster-wide storage definitions | `type` (optional filter: `nfs`, `pbs`, `dir`, `cifs`, `zfspool`, etc.) |
+| `get_storage` | Get full configuration of a storage definition | `storage` (name) |
+| `add_storage` | Add a new storage target to the cluster | `storage` (name), `type` (required: `nfs`\|`pbs`\|`dir`\|`cifs`\|`zfspool`\|...), `server` (optional), `export` (optional, NFS path), `path` (optional, dir path), `datastore` (optional, PBS datastore), `username` (optional), `password` (optional), `fingerprint` (optional, PBS TLS fingerprint), `content` (optional, e.g. `backup,images`), `nodes` (optional, comma-sep), `shared` (optional bool) |
+| `update_storage` | Update an existing storage definition | `storage` (name), plus any subset of the `add_storage` params |
+
 ### Destructive (opt-in)
 
 These tools are **not registered by default**. Set `PROXMOX_ALLOW_DESTRUCTIVE=true` to enable them.
@@ -126,6 +135,7 @@ These tools are **not registered by default**. Set `PROXMOX_ALLOW_DESTRUCTIVE=tr
 | `reboot_node` | Reboot an entire Proxmox node | `node`, `confirmed` (must be `true`) |
 | `shutdown_node` | Shut down an entire Proxmox node | `node`, `confirmed` (must be `true`) |
 | `delete_pool` | Permanently delete an empty resource pool | `poolid`, `confirmed` (must be `true`) |
+| `remove_storage` | Remove a storage definition from the cluster (does not affect underlying data) | `storage` (name), `confirmed` (must be `true`) |
 
 Lifecycle and snapshot operations are non-blocking — they return the UPID of the async task immediately. Use `get_task_status` to poll for completion.
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 | `list_storages` | List all cluster-wide storage definitions | `type` (optional filter: `nfs`, `pbs`, `dir`, `cifs`, `zfspool`, etc.) |
 | `get_storage` | Get full configuration of a storage definition | `storage` (name) |
 | `add_storage` | Add a new storage target to the cluster | `storage` (name), `type` (required: `nfs`\|`pbs`\|`dir`\|`cifs`\|`zfspool`\|...), `server` (optional), `export` (optional, NFS path), `path` (optional, dir path), `datastore` (optional, PBS datastore), `username` (optional), `password` (optional), `fingerprint` (optional, PBS TLS fingerprint), `content` (optional, e.g. `backup,images`), `nodes` (optional, comma-sep), `shared` (optional bool) |
-| `update_storage` | Update an existing storage definition | `storage` (name), plus any subset of the `add_storage` params |
+| `update_storage` | Update an existing storage definition | `storage` (name), plus any of: `server`, `export`, `path`, `datastore`, `username`, `password`, `fingerprint`, `content`, `nodes`, `shared` |
 
 ### Destructive (opt-in)
 

--- a/internal/proxmox/storagedef.go
+++ b/internal/proxmox/storagedef.go
@@ -1,0 +1,76 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// ListStorages returns all storage definitions configured cluster-wide.
+// The optional storageType parameter filters by type (e.g. "nfs", "pbs", "dir").
+// Pass an empty string to return all storage definitions.
+func (c *Client) ListStorages(ctx context.Context, storageType string) ([]map[string]any, error) {
+	path := "/storage"
+	if storageType != "" {
+		path += "?type=" + url.QueryEscape(storageType)
+	}
+
+	var result []map[string]any
+	if err := c.get(ctx, path, &result); err != nil {
+		return nil, fmt.Errorf("listing storage definitions: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetStorage returns the full configuration of a single storage definition.
+func (c *Client) GetStorage(ctx context.Context, storage string) (map[string]any, error) {
+	path := "/storage/" + url.PathEscape(storage)
+
+	var result map[string]any
+	if err := c.get(ctx, path, &result); err != nil {
+		return nil, fmt.Errorf("getting storage definition %q: %w", storage, err)
+	}
+
+	return result, nil
+}
+
+// AddStorage creates a new cluster-wide storage definition and returns the
+// resulting configuration.
+func (c *Client) AddStorage(ctx context.Context, req *AddStorageRequest) (map[string]any, error) {
+	if req == nil {
+		return nil, fmt.Errorf("adding storage: request is nil")
+	}
+
+	var result map[string]any
+	if err := c.postWithBody(ctx, "/storage", req, &result); err != nil {
+		return nil, fmt.Errorf("adding storage %q: %w", req.Storage, err)
+	}
+
+	return result, nil
+}
+
+// UpdateStorage updates an existing cluster-wide storage definition.
+// Only the fields set in req are changed; omitted fields are left as-is.
+func (c *Client) UpdateStorage(ctx context.Context, storage string, req *UpdateStorageRequest) error {
+	if req == nil {
+		return fmt.Errorf("updating storage %q: request is nil", storage)
+	}
+
+	if err := c.put(ctx, "/storage/"+url.PathEscape(storage), req, nil); err != nil {
+		return fmt.Errorf("updating storage %q: %w", storage, err)
+	}
+
+	return nil
+}
+
+// RemoveStorage permanently removes a storage definition from the cluster.
+// This only removes the Proxmox storage entry — it does not affect the
+// underlying storage server or any data stored on it.
+func (c *Client) RemoveStorage(ctx context.Context, storage string) error {
+	if err := c.delete(ctx, "/storage/"+url.PathEscape(storage), nil); err != nil {
+		return fmt.Errorf("removing storage %q: %w", storage, err)
+	}
+
+	return nil
+}

--- a/internal/proxmox/storagedef_test.go
+++ b/internal/proxmox/storagedef_test.go
@@ -2,7 +2,9 @@ package proxmox
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,7 +15,7 @@ func TestListStorages_success(t *testing.T) {
 
 	want := []map[string]any{
 		{"storage": "local", "type": "dir", "content": "iso,vztmpl,backup"},
-		{"storage": "nfs-backups", "type": "nfs", "server": "truenas.local"},
+		{"storage": "nfs-backups", "type": "nfs", "server": "pbs.storage.invalid"},
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/storage" {
@@ -41,7 +43,7 @@ func TestListStorages_withTypeFilter(t *testing.T) {
 	t.Parallel()
 
 	want := []map[string]any{
-		{"storage": "nfs-backups", "type": "nfs", "server": "truenas.local"},
+		{"storage": "nfs-backups", "type": "nfs", "server": "pbs.storage.invalid"},
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/storage" {
@@ -89,7 +91,7 @@ func TestGetStorage_success(t *testing.T) {
 	want := map[string]any{
 		"storage":   "pbs-store",
 		"type":      "pbs",
-		"server":    "truenas.local",
+		"server":    "pbs.storage.invalid",
 		"datastore": "pbs-ds",
 		"username":  "backup@pbs",
 		"content":   "backup",
@@ -136,7 +138,7 @@ func TestAddStorage_success(t *testing.T) {
 	req := &AddStorageRequest{
 		Storage:   "pbs-store",
 		Type:      "pbs",
-		Server:    "truenas.local",
+		Server:    "pbs.storage.invalid",
 		Datastore: "pbs-ds",
 		Username:  "backup@pbs",
 		Content:   "backup",
@@ -144,14 +146,21 @@ func TestAddStorage_success(t *testing.T) {
 	want := map[string]any{
 		"storage":   "pbs-store",
 		"type":      "pbs",
-		"server":    "truenas.local",
+		"server":    "pbs.storage.invalid",
 		"datastore": "pbs-ds",
 		"username":  "backup@pbs",
 		"content":   "backup",
 	}
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/storage" {
 			http.NotFound(w, r)
+			return
+		}
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -165,6 +174,23 @@ func TestAddStorage_success(t *testing.T) {
 	}
 	if got["storage"] != "pbs-store" {
 		t.Errorf("storage: got %v, want pbs-store", got["storage"])
+	}
+
+	// Verify request body contains expected fields.
+	var decoded map[string]any
+	if err := json.Unmarshal(gotBody, &decoded); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	for _, key := range []string{"storage", "type", "server", "datastore", "username", "content"} {
+		if decoded[key] == nil {
+			t.Errorf("field %q should be present in request body but was absent", key)
+		}
+	}
+	// Omitted fields must not appear in the body.
+	for _, key := range []string{"path", "export", "password", "fingerprint", "nodes"} {
+		if _, present := decoded[key]; present {
+			t.Errorf("field %q should be omitted (omitempty) but was present in request body", key)
+		}
 	}
 }
 
@@ -186,9 +212,16 @@ func TestAddStorage_apiError(t *testing.T) {
 func TestUpdateStorage_success(t *testing.T) {
 	t.Parallel()
 
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut || r.URL.Path != "/storage/pbs-store" {
 			http.NotFound(w, r)
+			return
+		}
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -196,9 +229,24 @@ func TestUpdateStorage_success(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	// Only set Content — all other fields must be absent (omitempty).
 	req := &UpdateStorageRequest{Content: "backup,iso"}
 	if err := newTestClient(t, srv.URL).UpdateStorage(context.Background(), "pbs-store", req); err != nil {
 		t.Fatalf("UpdateStorage: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(gotBody, &decoded); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	if decoded["content"] != "backup,iso" {
+		t.Errorf("content: got %v, want backup,iso", decoded["content"])
+	}
+	// Fields not set must not appear in the body.
+	for _, key := range []string{"server", "export", "path", "datastore", "username", "password", "fingerprint", "nodes"} {
+		if _, present := decoded[key]; present {
+			t.Errorf("field %q should be omitted (omitempty) but was present in request body", key)
+		}
 	}
 }
 

--- a/internal/proxmox/storagedef_test.go
+++ b/internal/proxmox/storagedef_test.go
@@ -209,6 +209,15 @@ func TestAddStorage_apiError(t *testing.T) {
 	}
 }
 
+func TestAddStorage_nilRequest(t *testing.T) {
+	t.Parallel()
+
+	_, err := newTestClient(t, "http://unused.invalid").AddStorage(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request, got nil")
+	}
+}
+
 func TestUpdateStorage_success(t *testing.T) {
 	t.Parallel()
 
@@ -261,6 +270,14 @@ func TestUpdateStorage_apiError(t *testing.T) {
 	req := &UpdateStorageRequest{Content: "invalid"}
 	if err := newTestClient(t, srv.URL).UpdateStorage(context.Background(), "pbs-store", req); err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestUpdateStorage_nilRequest(t *testing.T) {
+	t.Parallel()
+
+	if err := newTestClient(t, "http://unused.invalid").UpdateStorage(context.Background(), "pbs-store", nil); err == nil {
+		t.Fatal("expected error for nil request, got nil")
 	}
 }
 

--- a/internal/proxmox/storagedef_test.go
+++ b/internal/proxmox/storagedef_test.go
@@ -1,0 +1,248 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListStorages_success(t *testing.T) {
+	t.Parallel()
+
+	want := []map[string]any{
+		{"storage": "local", "type": "dir", "content": "iso,vztmpl,backup"},
+		{"storage": "nfs-backups", "type": "nfs", "server": "truenas.local"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/storage" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListStorages(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListStorages: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d storages, want %d", len(got), len(want))
+	}
+	if got[0]["storage"] != "local" {
+		t.Errorf("storage[0]: got %v, want local", got[0]["storage"])
+	}
+}
+
+func TestListStorages_withTypeFilter(t *testing.T) {
+	t.Parallel()
+
+	want := []map[string]any{
+		{"storage": "nfs-backups", "type": "nfs", "server": "truenas.local"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/storage" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("type") != "nfs" {
+			http.Error(w, "want type=nfs query param", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListStorages(context.Background(), "nfs")
+	if err != nil {
+		t.Fatalf("ListStorages with type filter: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d storages, want 1", len(got))
+	}
+	if got[0]["type"] != "nfs" {
+		t.Errorf("type: got %v, want nfs", got[0]["type"])
+	}
+}
+
+func TestListStorages_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).ListStorages(context.Background(), "")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetStorage_success(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]any{
+		"storage":   "pbs-store",
+		"type":      "pbs",
+		"server":    "truenas.local",
+		"datastore": "pbs-ds",
+		"username":  "backup@pbs",
+		"content":   "backup",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/storage/pbs-store" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).GetStorage(context.Background(), "pbs-store")
+	if err != nil {
+		t.Fatalf("GetStorage: %v", err)
+	}
+	if got["storage"] != "pbs-store" {
+		t.Errorf("storage: got %v, want pbs-store", got["storage"])
+	}
+	if got["type"] != "pbs" {
+		t.Errorf("type: got %v, want pbs", got["type"])
+	}
+}
+
+func TestGetStorage_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).GetStorage(context.Background(), "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestAddStorage_success(t *testing.T) {
+	t.Parallel()
+
+	req := &AddStorageRequest{
+		Storage:   "pbs-store",
+		Type:      "pbs",
+		Server:    "truenas.local",
+		Datastore: "pbs-ds",
+		Username:  "backup@pbs",
+		Content:   "backup",
+	}
+	want := map[string]any{
+		"storage":   "pbs-store",
+		"type":      "pbs",
+		"server":    "truenas.local",
+		"datastore": "pbs-ds",
+		"username":  "backup@pbs",
+		"content":   "backup",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/storage" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).AddStorage(context.Background(), req)
+	if err != nil {
+		t.Fatalf("AddStorage: %v", err)
+	}
+	if got["storage"] != "pbs-store" {
+		t.Errorf("storage: got %v, want pbs-store", got["storage"])
+	}
+}
+
+func TestAddStorage_apiError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "storage already exists", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	req := &AddStorageRequest{Storage: "dupe", Type: "dir", Path: "/mnt/dupe"}
+	_, err := newTestClient(t, srv.URL).AddStorage(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestUpdateStorage_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/storage/pbs-store" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, nil))
+	}))
+	defer srv.Close()
+
+	req := &UpdateStorageRequest{Content: "backup,iso"}
+	if err := newTestClient(t, srv.URL).UpdateStorage(context.Background(), "pbs-store", req); err != nil {
+		t.Fatalf("UpdateStorage: %v", err)
+	}
+}
+
+func TestUpdateStorage_apiError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "invalid content type", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	req := &UpdateStorageRequest{Content: "invalid"}
+	if err := newTestClient(t, srv.URL).UpdateStorage(context.Background(), "pbs-store", req); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRemoveStorage_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/storage/pbs-store" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, nil))
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(t, srv.URL).RemoveStorage(context.Background(), "pbs-store"); err != nil {
+		t.Fatalf("RemoveStorage: %v", err)
+	}
+}
+
+func TestRemoveStorage_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(t, srv.URL).RemoveStorage(context.Background(), "missing"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -345,6 +345,39 @@ type UpdatePoolRequest struct {
 	Delete  *int   `json:"delete,omitempty"`  // 1 = remove the listed members instead of adding them
 }
 
+// AddStorageRequest is the request body for POST /storage.
+// Only Storage and Type are required; all other fields are type-specific.
+type AddStorageRequest struct {
+	Storage     string          `json:"storage"`               // storage name (required)
+	Type        string          `json:"type"`                  // storage type, e.g. nfs, pbs, dir (required)
+	Content     string          `json:"content,omitempty"`     // comma-sep content types, e.g. "backup,images"
+	Nodes       string          `json:"nodes,omitempty"`       // restrict to these comma-sep nodes
+	Shared      *int            `json:"shared,omitempty"`      // 1 = accessible from all nodes
+	Server      string          `json:"server,omitempty"`      // NFS/PBS/CIFS server host
+	Export      string          `json:"export,omitempty"`      // NFS export path
+	Path        string          `json:"path,omitempty"`        // dir/local path
+	Datastore   string          `json:"datastore,omitempty"`   // PBS datastore name
+	Username    string          `json:"username,omitempty"`    // PBS/CIFS username
+	Password    SensitiveString `json:"password,omitempty"`    // PBS/CIFS password
+	Fingerprint string          `json:"fingerprint,omitempty"` // PBS server TLS fingerprint
+}
+
+// UpdateStorageRequest is the request body for PUT /storage/{storage}.
+// All fields are optional — only supplied fields are changed.
+// Type and Storage (name) cannot be changed after creation and are omitted here.
+type UpdateStorageRequest struct {
+	Content     string          `json:"content,omitempty"`     // comma-sep content types
+	Nodes       string          `json:"nodes,omitempty"`       // restrict to these comma-sep nodes
+	Shared      *int            `json:"shared,omitempty"`      // 1 = accessible from all nodes
+	Server      string          `json:"server,omitempty"`      // NFS/PBS/CIFS server host
+	Export      string          `json:"export,omitempty"`      // NFS export path
+	Path        string          `json:"path,omitempty"`        // dir/local path
+	Datastore   string          `json:"datastore,omitempty"`   // PBS datastore name
+	Username    string          `json:"username,omitempty"`    // PBS/CIFS username
+	Password    SensitiveString `json:"password,omitempty"`    // PBS/CIFS password
+	Fingerprint string          `json:"fingerprint,omitempty"` // PBS server TLS fingerprint
+}
+
 // APIError represents an HTTP-level error returned by the Proxmox API.
 type APIError struct {
 	StatusCode int

--- a/tools/destructive.go
+++ b/tools/destructive.go
@@ -61,6 +61,26 @@ func registerDestructiveTools(s *mcp.Server, client *proxmox.Client) {
 		return taskResult(upid)
 	})
 
+	type removeStorageInput struct {
+		Storage   string `json:"storage"   jsonschema:"name of the storage definition to remove (e.g. pbs-store)"`
+		Confirmed bool   `json:"confirmed" jsonschema:"must be set to true to confirm removal"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "remove_storage",
+		Description: "Remove a storage definition from the Proxmox cluster. This only removes the Proxmox entry — it does not affect the underlying server or data. Set confirmed=true to proceed.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: &destructiveHint,
+		},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input removeStorageInput) (*mcp.CallToolResult, any, error) {
+		if !input.Confirmed {
+			return nil, nil, errors.New("remove_storage: confirmed must be true to proceed with removal")
+		}
+		if err := client.RemoveStorage(ctx, input.Storage); err != nil {
+			return nil, nil, fmt.Errorf("remove_storage: %w", err)
+		}
+		return jsonResult(map[string]string{"storage": input.Storage, "status": "removed"})
+	})
+
 	type deleteStorageContentInput struct {
 		Node      string `json:"node"      jsonschema:"node the storage pool is on"`
 		Storage   string `json:"storage"   jsonschema:"name of the storage pool (e.g. local)"`

--- a/tools/register.go
+++ b/tools/register.go
@@ -26,6 +26,7 @@ func RegisterAll(s *mcp.Server, client *proxmox.Client, cfg Config) {
 	registerNetworkTools(s, client)
 	registerFirewallTools(s, client)
 	registerPoolTools(s, client)
+	registerStorageDefTools(s, client)
 	if cfg.AllowDestructive {
 		registerDestructiveTools(s, client)
 	}

--- a/tools/storagedef.go
+++ b/tools/storagedef.go
@@ -75,11 +75,10 @@ func registerStorageDefTools(s *mcp.Server, client *proxmox.Client) {
 			one := 1
 			req.Shared = &one
 		}
-		result, err := client.AddStorage(ctx, req)
-		if err != nil {
+		if _, err := client.AddStorage(ctx, req); err != nil {
 			return nil, nil, fmt.Errorf("add_storage: %w", err)
 		}
-		return jsonResult(result)
+		return jsonResult(map[string]string{"storage": input.Storage, "status": "created"})
 	})
 
 	type updateStorageInput struct {

--- a/tools/storagedef.go
+++ b/tools/storagedef.go
@@ -1,0 +1,127 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gordcurrie/proxmox-mcp/internal/proxmox"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerStorageDefTools adds cluster-wide storage definition MCP tools to the server.
+func registerStorageDefTools(s *mcp.Server, client *proxmox.Client) {
+	type listStoragesInput struct {
+		Type string `json:"type,omitempty" jsonschema:"optional storage type filter: nfs, pbs, dir, cifs, zfspool, lvmthin, etc."`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_storages",
+		Description: "List all cluster-wide storage definitions in Proxmox. Optionally filter by storage type (e.g. nfs, pbs, dir).",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input listStoragesInput) (*mcp.CallToolResult, any, error) {
+		storages, err := client.ListStorages(ctx, input.Type)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list_storages: %w", err)
+		}
+		return jsonResult(storages)
+	})
+
+	type getStorageInput struct {
+		Storage string `json:"storage" jsonschema:"name of the storage definition (e.g. local, pbs-store)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_storage",
+		Description: "Get the full configuration of a Proxmox storage definition.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input getStorageInput) (*mcp.CallToolResult, any, error) {
+		storage, err := client.GetStorage(ctx, input.Storage)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get_storage: %w", err)
+		}
+		return jsonResult(storage)
+	})
+
+	type addStorageInput struct {
+		Storage     string                  `json:"storage"                jsonschema:"unique name for the new storage (required)"`
+		Type        string                  `json:"type"                   jsonschema:"storage type: nfs, pbs, dir, cifs, zfspool, lvmthin, etc. (required)"`
+		Content     string                  `json:"content,omitempty"      jsonschema:"comma-separated content types to allow, e.g. backup,images,iso"`
+		Nodes       string                  `json:"nodes,omitempty"        jsonschema:"comma-separated list of nodes that can use this storage; omit for all nodes"`
+		Shared      bool                    `json:"shared,omitempty"       jsonschema:"true if the storage is accessible from all nodes simultaneously"`
+		Server      string                  `json:"server,omitempty"       jsonschema:"hostname or IP of the NFS, PBS, or CIFS server"`
+		Export      string                  `json:"export,omitempty"       jsonschema:"NFS export path on the server (NFS only)"`
+		Path        string                  `json:"path,omitempty"         jsonschema:"local filesystem path (dir type only)"`
+		Datastore   string                  `json:"datastore,omitempty"    jsonschema:"datastore name on the PBS server (pbs type only)"`
+		Username    string                  `json:"username,omitempty"     jsonschema:"username for PBS (e.g. backup@pbs) or CIFS authentication"`
+		Password    proxmox.SensitiveString `json:"password,omitempty"     jsonschema:"password for PBS or CIFS authentication"`
+		Fingerprint string                  `json:"fingerprint,omitempty"  jsonschema:"TLS certificate fingerprint of the PBS server for verification"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "add_storage",
+		Description: "Add a new cluster-wide storage definition to Proxmox. Supports nfs, pbs, dir, cifs, zfspool, and other types. For PBS: provide server, datastore, username, password. For NFS: provide server and export.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input addStorageInput) (*mcp.CallToolResult, any, error) {
+		req := &proxmox.AddStorageRequest{
+			Storage:     input.Storage,
+			Type:        input.Type,
+			Content:     input.Content,
+			Nodes:       input.Nodes,
+			Server:      input.Server,
+			Export:      input.Export,
+			Path:        input.Path,
+			Datastore:   input.Datastore,
+			Username:    input.Username,
+			Password:    input.Password,
+			Fingerprint: input.Fingerprint,
+		}
+		if input.Shared {
+			one := 1
+			req.Shared = &one
+		}
+		result, err := client.AddStorage(ctx, req)
+		if err != nil {
+			return nil, nil, fmt.Errorf("add_storage: %w", err)
+		}
+		return jsonResult(result)
+	})
+
+	type updateStorageInput struct {
+		Storage     string                  `json:"storage"                jsonschema:"name of the storage to update (required)"`
+		Content     string                  `json:"content,omitempty"      jsonschema:"comma-separated content types, e.g. backup,images"`
+		Nodes       string                  `json:"nodes,omitempty"        jsonschema:"comma-separated node names to restrict storage to"`
+		Shared      *bool                   `json:"shared,omitempty"       jsonschema:"true = accessible from all nodes, false = restrict"`
+		Server      string                  `json:"server,omitempty"       jsonschema:"new server hostname or IP"`
+		Export      string                  `json:"export,omitempty"       jsonschema:"new NFS export path"`
+		Path        string                  `json:"path,omitempty"         jsonschema:"new local path (dir type)"`
+		Datastore   string                  `json:"datastore,omitempty"    jsonschema:"new PBS datastore name"`
+		Username    string                  `json:"username,omitempty"     jsonschema:"new PBS/CIFS username"`
+		Password    proxmox.SensitiveString `json:"password,omitempty"     jsonschema:"new PBS/CIFS password"`
+		Fingerprint string                  `json:"fingerprint,omitempty"  jsonschema:"new PBS TLS fingerprint"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "update_storage",
+		Description: "Update the configuration of an existing Proxmox storage definition. Only supplied fields are changed; omitted fields are left as-is.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input updateStorageInput) (*mcp.CallToolResult, any, error) {
+		req := &proxmox.UpdateStorageRequest{
+			Content:     input.Content,
+			Nodes:       input.Nodes,
+			Server:      input.Server,
+			Export:      input.Export,
+			Path:        input.Path,
+			Datastore:   input.Datastore,
+			Username:    input.Username,
+			Password:    input.Password,
+			Fingerprint: input.Fingerprint,
+		}
+		if input.Shared != nil {
+			if *input.Shared {
+				one := 1
+				req.Shared = &one
+			} else {
+				zero := 0
+				req.Shared = &zero
+			}
+		}
+		if err := client.UpdateStorage(ctx, input.Storage, req); err != nil {
+			return nil, nil, fmt.Errorf("update_storage: %w", err)
+		}
+		return jsonResult(map[string]string{"storage": input.Storage, "status": "updated"})
+	})
+}


### PR DESCRIPTION
## Summary

Adds cluster-wide storage definition tools to proxmox-mcp, completing Phase 7. This is the key missing piece for the PBS + TrueNAS backup workflow — agents can now register an NFS share or a Proxmox Backup Server as a Proxmox storage target without touching the Proxmox UI.

## New tools

### Always-on (4 tools)

| Tool | Endpoint | Description |
|---|---|---|
| `list_storages` | `GET /storage` | List all storage definitions; optional `type` filter (nfs, pbs, dir, etc.) |
| `get_storage` | `GET /storage/{storage}` | Full config of a single storage definition |
| `add_storage` | `POST /storage` | Add a new storage target (nfs, pbs, dir, cifs, zfspool, ...) |
| `update_storage` | `PUT /storage/{storage}` | Update an existing storage definition |

### Destructive opt-in (1 tool)

| Tool | Endpoint | Description |
|---|---|---|
| `remove_storage` | `DELETE /storage/{storage}` | Remove a storage definition (does not affect underlying data) |

## Implementation notes

- New files: `internal/proxmox/storagedef.go`, `tools/storagedef.go`
- `AddStorageRequest` / `UpdateStorageRequest` types added to `types.go`
- `password` fields use `SensitiveString` (consistent with `CreateContainerRequest`)
- `remove_storage` follows the 3-layer safety pattern (`PROXMOX_ALLOW_DESTRUCTIVE` + `confirmed: true` + `DestructiveHint`), added to `tools/destructive.go`
- 10 new tests in `internal/proxmox/storagedef_test.go`
- `make check` passes cleanly (0 lint, 0 security issues)

## Example agent workflow (PBS on TrueNAS)

```
# On TrueNAS (truenas-mcp):
create_dataset  name=tank/pbs-datastore  compression=zstd
install_custom_app  app_name=pbs  custom_compose_config_string=<PBS compose YAML>

# On Proxmox (proxmox-mcp):
add_storage  storage=truenas-pbs  type=pbs  server=<truenas-ip>  datastore=pbs-datastore  username=backup@pbs  password=<token>  content=backup
create_backup  node=pve  vmid=100  storage=truenas-pbs  mode=snapshot  compress=zstd
```