### PR TITLE
feat: network interface write operations (4 new tools)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -114,6 +114,44 @@ Running total after PR #21: **76 tools** (70 always-on + 6 destructive).
 
 ---
 
+## Phase 8 — Network Write Operations (target: v0.8.0)
+
+Exposes the Proxmox node network write API so agents can create/update/delete
+interfaces and apply changes — enabling use cases like adding static-route bridge
+interfaces or pre-configuring SDN bridges.
+
+New methods added to `internal/proxmox/network.go`.
+New MCP tools added to `tools/network.go` and `tools/destructive.go`.
+
+### PR #25 — Network interface write (4 new tools)
+
+Closes issue #24.
+
+`create_node_network_interface` and `update_node_network_interface` use
+`postWithBody` / `put` with a `NetworkInterfaceConfig` struct.
+`apply_node_network_changes` uses an empty-body `put` (applies staged changes).
+`delete_node_network_interface` follows the 3-layer safety pattern
+(`PROXMOX_ALLOW_DESTRUCTIVE` + `confirmed: true` + `DestructiveHint`).
+
+Note: all changes to interfaces are staged in `/etc/network/interfaces.new` until
+`apply_node_network_changes` is called.
+
+| Tool | API endpoint | Params |
+|---|---|---|
+| `create_node_network_interface` | `POST /nodes/{node}/network` | `node`, `iface`, `type`, plus optional address/gateway/bridge/bond fields |
+| `update_node_network_interface` | `PUT /nodes/{node}/network/{iface}` | `node`, `iface`, `type`, plus optional address/gateway/bridge/bond fields |
+| `apply_node_network_changes` | `PUT /nodes/{node}/network` | `node` |
+| `delete_node_network_interface` | `DELETE /nodes/{node}/network/{iface}` | `node`, `iface`, `confirmed: true` — destructive opt-in |
+
+Tests: success + notFound for apply/delete; success + notFound + validation for
+create/update.
+
+**Phase 8 target tool count:** 76 + 4 = **80 tools** (73 always-on + 7 destructive).
+
+Running total after PR #25: **80 tools** (73 always-on + 7 destructive).
+
+---
+
 ## Proxmox API Notes
 
 - Base URL: `https://<host>:8006/api2/json`

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 |---|---|---|
 | `list_node_network` | List network interfaces on a node | `node`, `type` (optional: `bridge`, `bond`, `eth`, `alias`, `vlan`, `OVSBridge`, `OVSBond`, `OVSPort`, `OVSIntPort`, `any_bridge`) |
 | `get_node_network_interface` | Get configuration of a specific network interface | `node`, `iface` (e.g. `vmbr0`) |
-| `create_node_network_interface` | Create a new network interface on a node (staged until `apply_node_network_changes`) | `node`, `iface`, `type` (`bridge`\|`bond`\|`eth`\|`alias`\|`vlan`), `address` (optional), `netmask` (optional), `gateway` (optional), `address6` (optional), `gateway6` (optional), `mtu` (optional), `autostart` (optional), `bridge_ports` (optional), `bridge_stp` (optional), `bridge_fd` (optional), `bond_mode` (optional), `slaves` (optional), `comments` (optional) |
-| `update_node_network_interface` | Update an existing network interface on a node (staged until `apply_node_network_changes`) | `node`, `iface`, `type` (required), plus any optional fields as in `create_node_network_interface` |
+| `create_node_network_interface` | Create a new network interface on a node (staged until `apply_node_network_changes`) | `node`, `iface`, `type` (`bridge`\|`bond`\|`eth`\|`alias`\|`vlan`\|`OVSBridge`\|`OVSBond`\|`OVSPort`\|`OVSIntPort`), `address` (optional, dotted-decimal or CIDR), `netmask` (optional), `gateway` (optional), `address6` (optional, CIDR), `gateway6` (optional), `mtu` (optional), `autostart` (optional, `1`=boot, `0`=manual), `bridge_ports` (optional), `bridge_stp` (optional), `bridge_fd` (optional), `bond_mode` (optional), `slaves` (optional), `comments` (optional) |
+| `update_node_network_interface` | Update an existing network interface on a node (staged until `apply_node_network_changes`) | `node`, `iface`, `type` (required: same values as `create_node_network_interface`), plus any optional fields as in `create_node_network_interface` |
 | `apply_node_network_changes` | Apply all staged network configuration changes on a node, reloading the network stack | `node` |
 
 ### Firewall

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 |---|---|---|
 | `list_node_network` | List network interfaces on a node | `node`, `type` (optional: `bridge`, `bond`, `eth`, `alias`, `vlan`, `OVSBridge`, `OVSBond`, `OVSPort`, `OVSIntPort`, `any_bridge`) |
 | `get_node_network_interface` | Get configuration of a specific network interface | `node`, `iface` (e.g. `vmbr0`) |
+| `create_node_network_interface` | Create a new network interface on a node (staged until `apply_node_network_changes`) | `node`, `iface`, `type` (`bridge`\|`bond`\|`eth`\|`alias`\|`vlan`), `address` (optional), `netmask` (optional), `gateway` (optional), `address6` (optional), `gateway6` (optional), `mtu` (optional), `autostart` (optional), `bridge_ports` (optional), `bridge_stp` (optional), `bridge_fd` (optional), `bond_mode` (optional), `slaves` (optional), `comments` (optional) |
+| `update_node_network_interface` | Update an existing network interface on a node (staged until `apply_node_network_changes`) | `node`, `iface`, `type` (required), plus any optional fields as in `create_node_network_interface` |
+| `apply_node_network_changes` | Apply all staged network configuration changes on a node, reloading the network stack | `node` |
 
 ### Firewall
 
@@ -136,6 +139,7 @@ These tools are **not registered by default**. Set `PROXMOX_ALLOW_DESTRUCTIVE=tr
 | `shutdown_node` | Shut down an entire Proxmox node | `node`, `confirmed` (must be `true`) |
 | `delete_pool` | Permanently delete an empty resource pool | `poolid`, `confirmed` (must be `true`) |
 | `remove_storage` | Remove a storage definition from the cluster (does not affect underlying data) | `storage` (name), `confirmed` (must be `true`) |
+| `delete_node_network_interface` | Remove a network interface from a node (staged until `apply_node_network_changes`) | `node`, `iface`, `confirmed` (must be `true`) |
 
 Lifecycle and snapshot operations are non-blocking — they return the UPID of the async task immediately. Use `get_task_status` to poll for completion.
 

--- a/internal/proxmox/network.go
+++ b/internal/proxmox/network.go
@@ -36,3 +36,113 @@ func (c *Client) GetNodeNetworkInterface(ctx context.Context, node, iface string
 
 	return result, nil
 }
+
+// NetworkInterfaceConfig holds the configurable fields for a Proxmox node
+// network interface. Used for both creating and updating interfaces.
+// Not all fields apply to all interface types:
+//   - bridge: BridgePorts, BridgeSTP, BridgeFD
+//   - bond:   BondMode, Slaves
+type NetworkInterfaceConfig struct {
+	// Type is required. Valid values: bridge, bond, eth, alias, vlan,
+	// OVSBridge, OVSBond, OVSPort, OVSIntPort.
+	Type        string `json:"type"`
+	Address     string `json:"address,omitempty"`      // IPv4 address in CIDR or dotted-decimal
+	Netmask     string `json:"netmask,omitempty"`      // subnet mask (alternative to CIDR in address)
+	Gateway     string `json:"gateway,omitempty"`      // default IPv4 gateway
+	Address6    string `json:"address6,omitempty"`     // IPv6 address in CIDR
+	Gateway6    string `json:"gateway6,omitempty"`     // default IPv6 gateway
+	MTU         int    `json:"mtu,omitempty"`          // maximum transmission unit
+	Autostart   int    `json:"autostart,omitempty"`    // 1 = start on boot, 0 = manual
+	BridgePorts string `json:"bridge_ports,omitempty"` // space-separated list of member ports
+	BridgeSTP   string `json:"bridge_stp,omitempty"`   // spanning tree protocol: "on" or "off"
+	BridgeFD    int    `json:"bridge_fd,omitempty"`    // bridge forward delay (seconds)
+	BondMode    string `json:"bond_mode,omitempty"`    // active-backup, 802.3ad, etc.
+	Slaves      string `json:"slaves,omitempty"`       // space-separated list of bond member ports
+	Comments    string `json:"comments,omitempty"`     // free-text; may include post-up/pre-down lines
+}
+
+// createNetworkInterfaceBody is the internal wire body for POST /nodes/{node}/network.
+// It combines the interface name (required in the POST body) with the config fields.
+type createNetworkInterfaceBody struct {
+	Iface string `json:"iface"`
+	NetworkInterfaceConfig
+}
+
+// CreateNodeNetworkInterface creates a new network interface on the specified
+// node. The changes are staged (written to /etc/network/interfaces.new) and
+// must be applied with ApplyNodeNetworkChanges to take effect.
+func (c *Client) CreateNodeNetworkInterface(ctx context.Context, node, iface string, cfg *NetworkInterfaceConfig) (map[string]any, error) {
+	if node == "" {
+		return nil, fmt.Errorf("creating network interface on node: node must not be empty")
+	}
+	if iface == "" {
+		return nil, fmt.Errorf("creating network interface on node %s: iface must not be empty", node)
+	}
+	if cfg == nil {
+		return nil, fmt.Errorf("creating network interface %s on node %s: config must not be nil", iface, node)
+	}
+	if cfg.Type == "" {
+		return nil, fmt.Errorf("creating network interface %s on node %s: type must not be empty", iface, node)
+	}
+
+	body := createNetworkInterfaceBody{Iface: iface, NetworkInterfaceConfig: *cfg}
+	var result map[string]any
+	if err := c.postWithBody(ctx, "/nodes/"+url.PathEscape(node)+"/network", body, &result); err != nil {
+		return nil, fmt.Errorf("creating network interface %s on node %s: %w", iface, node, err)
+	}
+	return result, nil
+}
+
+// UpdateNodeNetworkInterface modifies the configuration of an existing network
+// interface on the specified node. The changes are staged and must be applied
+// with ApplyNodeNetworkChanges to take effect.
+func (c *Client) UpdateNodeNetworkInterface(ctx context.Context, node, iface string, cfg *NetworkInterfaceConfig) error {
+	if node == "" {
+		return fmt.Errorf("updating network interface on node: node must not be empty")
+	}
+	if iface == "" {
+		return fmt.Errorf("updating network interface on node %s: iface must not be empty", node)
+	}
+	if cfg == nil {
+		return fmt.Errorf("updating network interface %s on node %s: config must not be nil", iface, node)
+	}
+	if cfg.Type == "" {
+		return fmt.Errorf("updating network interface %s on node %s: type must not be empty", iface, node)
+	}
+
+	path := "/nodes/" + url.PathEscape(node) + "/network/" + url.PathEscape(iface)
+	if err := c.put(ctx, path, cfg, nil); err != nil {
+		return fmt.Errorf("updating network interface %s on node %s: %w", iface, node, err)
+	}
+	return nil
+}
+
+// ApplyNodeNetworkChanges applies all staged network configuration changes on
+// the specified node, reloading the network stack. This is equivalent to
+// clicking "Apply Configuration" in the Proxmox web UI.
+func (c *Client) ApplyNodeNetworkChanges(ctx context.Context, node string) error {
+	if node == "" {
+		return fmt.Errorf("applying network changes: node must not be empty")
+	}
+	if err := c.put(ctx, "/nodes/"+url.PathEscape(node)+"/network", struct{}{}, nil); err != nil {
+		return fmt.Errorf("applying network changes on node %s: %w", node, err)
+	}
+	return nil
+}
+
+// DeleteNodeNetworkInterface removes an interface from the specified node's
+// network configuration. Changes are staged and must be applied with
+// ApplyNodeNetworkChanges to take effect.
+func (c *Client) DeleteNodeNetworkInterface(ctx context.Context, node, iface string) error {
+	if node == "" {
+		return fmt.Errorf("deleting network interface on node: node must not be empty")
+	}
+	if iface == "" {
+		return fmt.Errorf("deleting network interface on node %s: iface must not be empty", node)
+	}
+	path := "/nodes/" + url.PathEscape(node) + "/network/" + url.PathEscape(iface)
+	if err := c.delete(ctx, path, nil); err != nil {
+		return fmt.Errorf("deleting network interface %s on node %s: %w", iface, node, err)
+	}
+	return nil
+}

--- a/internal/proxmox/network.go
+++ b/internal/proxmox/network.go
@@ -52,10 +52,10 @@ type NetworkInterfaceConfig struct {
 	Address6    string `json:"address6,omitempty"`     // IPv6 address in CIDR
 	Gateway6    string `json:"gateway6,omitempty"`     // default IPv6 gateway
 	MTU         int    `json:"mtu,omitempty"`          // maximum transmission unit
-	Autostart   int    `json:"autostart,omitempty"`    // 1 = start on boot, 0 = manual
+	Autostart   *int   `json:"autostart,omitempty"`    // 1 = start on boot, 0 = manual; nil = omit
 	BridgePorts string `json:"bridge_ports,omitempty"` // space-separated list of member ports
 	BridgeSTP   string `json:"bridge_stp,omitempty"`   // spanning tree protocol: "on" or "off"
-	BridgeFD    int    `json:"bridge_fd,omitempty"`    // bridge forward delay (seconds)
+	BridgeFD    *int   `json:"bridge_fd,omitempty"`    // bridge forward delay (seconds); nil = omit
 	BondMode    string `json:"bond_mode,omitempty"`    // active-backup, 802.3ad, etc.
 	Slaves      string `json:"slaves,omitempty"`       // space-separated list of bond member ports
 	Comments    string `json:"comments,omitempty"`     // free-text; may include post-up/pre-down lines
@@ -120,6 +120,8 @@ func (c *Client) UpdateNodeNetworkInterface(ctx context.Context, node, iface str
 // ApplyNodeNetworkChanges applies all staged network configuration changes on
 // the specified node, reloading the network stack. This is equivalent to
 // clicking "Apply Configuration" in the Proxmox web UI.
+// Note: put always marshals the body, so the wire request carries {} as the
+// JSON body. Proxmox accepts this form for the apply endpoint.
 func (c *Client) ApplyNodeNetworkChanges(ctx context.Context, node string) error {
 	if node == "" {
 		return fmt.Errorf("applying network changes: node must not be empty")

--- a/internal/proxmox/network_test.go
+++ b/internal/proxmox/network_test.go
@@ -2,7 +2,9 @@ package proxmox
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -133,9 +135,16 @@ func TestCreateNodeNetworkInterface_success(t *testing.T) {
 	t.Parallel()
 
 	want := map[string]any{"iface": "vmbr1", "type": "bridge"}
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/nodes/pve1/network" {
 			http.NotFound(w, r)
+			return
+		}
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -152,6 +161,20 @@ func TestCreateNodeNetworkInterface_success(t *testing.T) {
 	}
 	if got["iface"] != "vmbr1" {
 		t.Errorf("iface: got %v, want vmbr1", got["iface"])
+	}
+
+	// Verify the request body encodes iface, type, and bridge_ports.
+	var decoded map[string]any
+	if err := json.Unmarshal(gotBody, &decoded); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	for _, key := range []string{"iface", "type", "bridge_ports"} {
+		if decoded[key] == nil {
+			t.Errorf("field %q should be present in request body but was absent", key)
+		}
+	}
+	if decoded["iface"] != "vmbr1" {
+		t.Errorf("request body iface: got %v, want vmbr1", decoded["iface"])
 	}
 }
 
@@ -201,9 +224,16 @@ func TestCreateNodeNetworkInterface_validation(t *testing.T) {
 func TestUpdateNodeNetworkInterface_success(t *testing.T) {
 	t.Parallel()
 
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut || r.URL.Path != "/nodes/pve1/network/vmbr0" {
 			http.NotFound(w, r)
+			return
+		}
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -217,6 +247,21 @@ func TestUpdateNodeNetworkInterface_success(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("UpdateNodeNetworkInterface: %v", err)
+	}
+
+	// Verify the request body encodes type and comments.
+	var decoded map[string]any
+	if err := json.Unmarshal(gotBody, &decoded); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	for _, key := range []string{"type", "comments"} {
+		if decoded[key] == nil {
+			t.Errorf("field %q should be present in request body but was absent", key)
+		}
+	}
+	// iface must not appear in an update body.
+	if _, present := decoded["iface"]; present {
+		t.Errorf("field \"iface\" should be absent from update request body but was present")
 	}
 }
 
@@ -266,9 +311,16 @@ func TestUpdateNodeNetworkInterface_validation(t *testing.T) {
 func TestApplyNodeNetworkChanges_success(t *testing.T) {
 	t.Parallel()
 
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut || r.URL.Path != "/nodes/pve1/network" {
 			http.NotFound(w, r)
+			return
+		}
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -278,6 +330,10 @@ func TestApplyNodeNetworkChanges_success(t *testing.T) {
 
 	if err := newTestClient(t, srv.URL).ApplyNodeNetworkChanges(context.Background(), "pve1"); err != nil {
 		t.Fatalf("ApplyNodeNetworkChanges: %v", err)
+	}
+	// put always marshals the body; struct{}{} produces {}.
+	if string(gotBody) != "{}" {
+		t.Errorf("ApplyNodeNetworkChanges request body: got %q, want \"{}\"", string(gotBody))
 	}
 }
 

--- a/internal/proxmox/network_test.go
+++ b/internal/proxmox/network_test.go
@@ -382,3 +382,65 @@ func TestDeleteNodeNetworkInterface_notFound(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestCreateNodeNetworkInterface_apiError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "invalid interface configuration", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).CreateNodeNetworkInterface(
+		context.Background(), "pve1", "vmbr1",
+		&NetworkInterfaceConfig{Type: "bridge"},
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestUpdateNodeNetworkInterface_apiError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "interface is in use", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	err := newTestClient(t, srv.URL).UpdateNodeNetworkInterface(
+		context.Background(), "pve1", "vmbr0",
+		&NetworkInterfaceConfig{Type: "bridge"},
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestApplyNodeNetworkChanges_apiError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "network configuration error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	err := newTestClient(t, srv.URL).ApplyNodeNetworkChanges(context.Background(), "pve1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestDeleteNodeNetworkInterface_apiError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "interface not found", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	err := newTestClient(t, srv.URL).DeleteNodeNetworkInterface(context.Background(), "pve1", "vmbr1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/proxmox/network_test.go
+++ b/internal/proxmox/network_test.go
@@ -128,3 +128,201 @@ func TestGetNodeNetworkInterface_notFound(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestCreateNodeNetworkInterface_success(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]any{"iface": "vmbr1", "type": "bridge"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/nodes/pve1/network" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).CreateNodeNetworkInterface(
+		context.Background(), "pve1", "vmbr1",
+		&NetworkInterfaceConfig{Type: "bridge", BridgePorts: "eth1"},
+	)
+	if err != nil {
+		t.Fatalf("CreateNodeNetworkInterface: %v", err)
+	}
+	if got["iface"] != "vmbr1" {
+		t.Errorf("iface: got %v, want vmbr1", got["iface"])
+	}
+}
+
+func TestCreateNodeNetworkInterface_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).CreateNodeNetworkInterface(
+		context.Background(), "missing", "vmbr1",
+		&NetworkInterfaceConfig{Type: "bridge"},
+	)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestCreateNodeNetworkInterface_validation(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient(t, "http://localhost:9")
+	tests := []struct {
+		name  string
+		node  string
+		iface string
+		cfg   *NetworkInterfaceConfig
+	}{
+		{"empty node", "", "vmbr1", &NetworkInterfaceConfig{Type: "bridge"}},
+		{"empty iface", "pve1", "", &NetworkInterfaceConfig{Type: "bridge"}},
+		{"nil cfg", "pve1", "vmbr1", nil},
+		{"empty type", "pve1", "vmbr1", &NetworkInterfaceConfig{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := c.CreateNodeNetworkInterface(context.Background(), tt.node, tt.iface, tt.cfg)
+			if err == nil {
+				t.Errorf("expected error for %q, got nil", tt.name)
+			}
+		})
+	}
+}
+
+func TestUpdateNodeNetworkInterface_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/nodes/pve1/network/vmbr0" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, nil))
+	}))
+	defer srv.Close()
+
+	err := newTestClient(t, srv.URL).UpdateNodeNetworkInterface(
+		context.Background(), "pve1", "vmbr0",
+		&NetworkInterfaceConfig{Type: "bridge", Comments: "updated by mcp"},
+	)
+	if err != nil {
+		t.Fatalf("UpdateNodeNetworkInterface: %v", err)
+	}
+}
+
+func TestUpdateNodeNetworkInterface_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	err := newTestClient(t, srv.URL).UpdateNodeNetworkInterface(
+		context.Background(), "pve1", "missing0",
+		&NetworkInterfaceConfig{Type: "bridge"},
+	)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestUpdateNodeNetworkInterface_validation(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient(t, "http://localhost:9")
+	tests := []struct {
+		name  string
+		node  string
+		iface string
+		cfg   *NetworkInterfaceConfig
+	}{
+		{"empty node", "", "vmbr0", &NetworkInterfaceConfig{Type: "bridge"}},
+		{"empty iface", "pve1", "", &NetworkInterfaceConfig{Type: "bridge"}},
+		{"nil cfg", "pve1", "vmbr0", nil},
+		{"empty type", "pve1", "vmbr0", &NetworkInterfaceConfig{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := c.UpdateNodeNetworkInterface(context.Background(), tt.node, tt.iface, tt.cfg)
+			if err == nil {
+				t.Errorf("expected error for %q, got nil", tt.name)
+			}
+		})
+	}
+}
+
+func TestApplyNodeNetworkChanges_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/nodes/pve1/network" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, nil))
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(t, srv.URL).ApplyNodeNetworkChanges(context.Background(), "pve1"); err != nil {
+		t.Fatalf("ApplyNodeNetworkChanges: %v", err)
+	}
+}
+
+func TestApplyNodeNetworkChanges_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	err := newTestClient(t, srv.URL).ApplyNodeNetworkChanges(context.Background(), "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDeleteNodeNetworkInterface_success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/nodes/pve1/network/vmbr1" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, nil))
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(t, srv.URL).DeleteNodeNetworkInterface(context.Background(), "pve1", "vmbr1"); err != nil {
+		t.Fatalf("DeleteNodeNetworkInterface: %v", err)
+	}
+}
+
+func TestDeleteNodeNetworkInterface_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	err := newTestClient(t, srv.URL).DeleteNodeNetworkInterface(context.Background(), "pve1", "missing0")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/tools/destructive.go
+++ b/tools/destructive.go
@@ -159,4 +159,29 @@ func registerDestructiveTools(s *mcp.Server, client *proxmox.Client) {
 		}
 		return textResult("pool deleted: " + input.PoolID)
 	})
+
+	type deleteNodeNetworkInterfaceInput struct {
+		Node      string `json:"node"      jsonschema:"required,name of the node (e.g. pve)"`
+		Iface     string `json:"iface"     jsonschema:"required,interface name to delete (e.g. vmbr1)"`
+		Confirmed bool   `json:"confirmed" jsonschema:"must be set to true to confirm deletion"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "delete_node_network_interface",
+		Description: "Remove a network interface from a Proxmox node. Changes are staged until apply_node_network_changes is called. Set confirmed=true to proceed.",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: &destructiveHint,
+		},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input deleteNodeNetworkInterfaceInput) (*mcp.CallToolResult, any, error) {
+		if !input.Confirmed {
+			return nil, nil, errors.New("delete_node_network_interface: confirmed must be true to proceed with deletion")
+		}
+		if err := client.DeleteNodeNetworkInterface(ctx, input.Node, input.Iface); err != nil {
+			return nil, nil, fmt.Errorf("delete_node_network_interface: %w", err)
+		}
+		return jsonResult(map[string]string{
+			"node":   input.Node,
+			"iface":  input.Iface,
+			"status": "deleted (staged — call apply_node_network_changes to make permanent)",
+		})
+	})
 }

--- a/tools/network.go
+++ b/tools/network.go
@@ -41,4 +41,106 @@ func registerNetworkTools(s *mcp.Server, client *proxmox.Client) {
 		}
 		return jsonResult(iface)
 	})
+
+	type createNodeNetworkInterfaceInput struct {
+		Node        string `json:"node"                    jsonschema:"required,name of the node (e.g. pve)"`
+		Iface       string `json:"iface"                   jsonschema:"required,interface name to create (e.g. vmbr1)"`
+		Type        string `json:"type"                    jsonschema:"required,interface type: bridge, bond, eth, alias, vlan"`
+		Address     string `json:"address,omitempty"       jsonschema:"IPv4 address in dotted-decimal notation"`
+		Netmask     string `json:"netmask,omitempty"       jsonschema:"IPv4 subnet mask"`
+		Gateway     string `json:"gateway,omitempty"       jsonschema:"default IPv4 gateway"`
+		Address6    string `json:"address6,omitempty"      jsonschema:"IPv6 address"`
+		Gateway6    string `json:"gateway6,omitempty"      jsonschema:"default IPv6 gateway"`
+		MTU         int    `json:"mtu,omitempty"           jsonschema:"maximum transmission unit in bytes"`
+		Autostart   int    `json:"autostart,omitempty"     jsonschema:"1 to start on boot, 0 for manual"`
+		BridgePorts string `json:"bridge_ports,omitempty"  jsonschema:"space-separated list of bridge member ports (bridge type only)"`
+		BridgeSTP   string `json:"bridge_stp,omitempty"    jsonschema:"spanning tree protocol: on or off (bridge type only)"`
+		BridgeFD    int    `json:"bridge_fd,omitempty"     jsonschema:"bridge forward delay in seconds (bridge type only)"`
+		BondMode    string `json:"bond_mode,omitempty"     jsonschema:"bond mode: active-backup, 802.3ad, etc. (bond type only)"`
+		Slaves      string `json:"slaves,omitempty"        jsonschema:"space-separated bond member ports (bond type only)"`
+		Comments    string `json:"comments,omitempty"      jsonschema:"free-text comments; may include post-up/pre-down routing lines for static routes"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "create_node_network_interface",
+		Description: "Create a new network interface on a Proxmox node. Changes are staged until apply_node_network_changes is called.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input createNodeNetworkInterfaceInput) (*mcp.CallToolResult, any, error) {
+		cfg := &proxmox.NetworkInterfaceConfig{
+			Type:        input.Type,
+			Address:     input.Address,
+			Netmask:     input.Netmask,
+			Gateway:     input.Gateway,
+			Address6:    input.Address6,
+			Gateway6:    input.Gateway6,
+			MTU:         input.MTU,
+			Autostart:   input.Autostart,
+			BridgePorts: input.BridgePorts,
+			BridgeSTP:   input.BridgeSTP,
+			BridgeFD:    input.BridgeFD,
+			BondMode:    input.BondMode,
+			Slaves:      input.Slaves,
+			Comments:    input.Comments,
+		}
+		result, err := client.CreateNodeNetworkInterface(ctx, input.Node, input.Iface, cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("create_node_network_interface: %w", err)
+		}
+		return jsonResult(result)
+	})
+
+	type updateNodeNetworkInterfaceInput struct {
+		Node        string `json:"node"                    jsonschema:"required,name of the node (e.g. pve)"`
+		Iface       string `json:"iface"                   jsonschema:"required,interface name to update (e.g. vmbr0)"`
+		Type        string `json:"type"                    jsonschema:"required,interface type: bridge, bond, eth, alias, vlan"`
+		Address     string `json:"address,omitempty"       jsonschema:"IPv4 address in dotted-decimal notation"`
+		Netmask     string `json:"netmask,omitempty"       jsonschema:"IPv4 subnet mask"`
+		Gateway     string `json:"gateway,omitempty"       jsonschema:"default IPv4 gateway"`
+		Address6    string `json:"address6,omitempty"      jsonschema:"IPv6 address"`
+		Gateway6    string `json:"gateway6,omitempty"      jsonschema:"default IPv6 gateway"`
+		MTU         int    `json:"mtu,omitempty"           jsonschema:"maximum transmission unit in bytes"`
+		Autostart   int    `json:"autostart,omitempty"     jsonschema:"1 to start on boot, 0 for manual"`
+		BridgePorts string `json:"bridge_ports,omitempty"  jsonschema:"space-separated list of bridge member ports (bridge type only)"`
+		BridgeSTP   string `json:"bridge_stp,omitempty"    jsonschema:"spanning tree protocol: on or off (bridge type only)"`
+		BridgeFD    int    `json:"bridge_fd,omitempty"     jsonschema:"bridge forward delay in seconds (bridge type only)"`
+		BondMode    string `json:"bond_mode,omitempty"     jsonschema:"bond mode: active-backup, 802.3ad, etc. (bond type only)"`
+		Slaves      string `json:"slaves,omitempty"        jsonschema:"space-separated bond member ports (bond type only)"`
+		Comments    string `json:"comments,omitempty"      jsonschema:"free-text comments; may include post-up/pre-down routing lines for static routes"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "update_node_network_interface",
+		Description: "Update the configuration of an existing network interface on a Proxmox node. Changes are staged until apply_node_network_changes is called.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input updateNodeNetworkInterfaceInput) (*mcp.CallToolResult, any, error) {
+		cfg := &proxmox.NetworkInterfaceConfig{
+			Type:        input.Type,
+			Address:     input.Address,
+			Netmask:     input.Netmask,
+			Gateway:     input.Gateway,
+			Address6:    input.Address6,
+			Gateway6:    input.Gateway6,
+			MTU:         input.MTU,
+			Autostart:   input.Autostart,
+			BridgePorts: input.BridgePorts,
+			BridgeSTP:   input.BridgeSTP,
+			BridgeFD:    input.BridgeFD,
+			BondMode:    input.BondMode,
+			Slaves:      input.Slaves,
+			Comments:    input.Comments,
+		}
+		if err := client.UpdateNodeNetworkInterface(ctx, input.Node, input.Iface, cfg); err != nil {
+			return nil, nil, fmt.Errorf("update_node_network_interface: %w", err)
+		}
+		return jsonResult(map[string]string{"node": input.Node, "iface": input.Iface, "status": "updated"})
+	})
+
+	type applyNodeNetworkChangesInput struct {
+		Node string `json:"node" jsonschema:"required,name of the node (e.g. pve)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "apply_node_network_changes",
+		Description: "Apply all staged network configuration changes on a Proxmox node, reloading the network stack. Must be called after create_node_network_interface, update_node_network_interface, or delete_node_network_interface to make changes take effect.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input applyNodeNetworkChangesInput) (*mcp.CallToolResult, any, error) {
+		if err := client.ApplyNodeNetworkChanges(ctx, input.Node); err != nil {
+			return nil, nil, fmt.Errorf("apply_node_network_changes: %w", err)
+		}
+		return textResult("network changes applied on node " + input.Node)
+	})
 }

--- a/tools/network.go
+++ b/tools/network.go
@@ -45,17 +45,17 @@ func registerNetworkTools(s *mcp.Server, client *proxmox.Client) {
 	type createNodeNetworkInterfaceInput struct {
 		Node        string `json:"node"                    jsonschema:"required,name of the node (e.g. pve)"`
 		Iface       string `json:"iface"                   jsonschema:"required,interface name to create (e.g. vmbr1)"`
-		Type        string `json:"type"                    jsonschema:"required,interface type: bridge, bond, eth, alias, vlan"`
-		Address     string `json:"address,omitempty"       jsonschema:"IPv4 address in dotted-decimal notation"`
+		Type        string `json:"type"                    jsonschema:"required,interface type: bridge, bond, eth, alias, vlan, OVSBridge, OVSBond, OVSPort, OVSIntPort"`
+		Address     string `json:"address,omitempty"       jsonschema:"IPv4 address or CIDR (e.g. 192.168.1.10 or 192.168.1.10/24)"`
 		Netmask     string `json:"netmask,omitempty"       jsonschema:"IPv4 subnet mask"`
-		Gateway     string `json:"gateway,omitempty"       jsonschema:"default IPv4 gateway"`
-		Address6    string `json:"address6,omitempty"      jsonschema:"IPv6 address"`
-		Gateway6    string `json:"gateway6,omitempty"      jsonschema:"default IPv6 gateway"`
+		Gateway     string `json:"gateway,omitempty"       jsonschema:"default IPv4 gateway address"`
+		Address6    string `json:"address6,omitempty"      jsonschema:"IPv6 address or CIDR (e.g. 2001:db8::1 or 2001:db8::1/64)"`
+		Gateway6    string `json:"gateway6,omitempty"      jsonschema:"default IPv6 gateway address"`
 		MTU         int    `json:"mtu,omitempty"           jsonschema:"maximum transmission unit in bytes"`
-		Autostart   int    `json:"autostart,omitempty"     jsonschema:"1 to start on boot, 0 for manual"`
+		Autostart   *int   `json:"autostart,omitempty"     jsonschema:"1 to start on boot, 0 for manual; omit to leave unchanged"`
 		BridgePorts string `json:"bridge_ports,omitempty"  jsonschema:"space-separated list of bridge member ports (bridge type only)"`
 		BridgeSTP   string `json:"bridge_stp,omitempty"    jsonschema:"spanning tree protocol: on or off (bridge type only)"`
-		BridgeFD    int    `json:"bridge_fd,omitempty"     jsonschema:"bridge forward delay in seconds (bridge type only)"`
+		BridgeFD    *int   `json:"bridge_fd,omitempty"     jsonschema:"bridge forward delay in seconds (bridge type only); omit to leave unchanged"`
 		BondMode    string `json:"bond_mode,omitempty"     jsonschema:"bond mode: active-backup, 802.3ad, etc. (bond type only)"`
 		Slaves      string `json:"slaves,omitempty"        jsonschema:"space-separated bond member ports (bond type only)"`
 		Comments    string `json:"comments,omitempty"      jsonschema:"free-text comments; may include post-up/pre-down routing lines for static routes"`
@@ -90,17 +90,17 @@ func registerNetworkTools(s *mcp.Server, client *proxmox.Client) {
 	type updateNodeNetworkInterfaceInput struct {
 		Node        string `json:"node"                    jsonschema:"required,name of the node (e.g. pve)"`
 		Iface       string `json:"iface"                   jsonschema:"required,interface name to update (e.g. vmbr0)"`
-		Type        string `json:"type"                    jsonschema:"required,interface type: bridge, bond, eth, alias, vlan"`
-		Address     string `json:"address,omitempty"       jsonschema:"IPv4 address in dotted-decimal notation"`
+		Type        string `json:"type"                    jsonschema:"required,interface type: bridge, bond, eth, alias, vlan, OVSBridge, OVSBond, OVSPort, OVSIntPort"`
+		Address     string `json:"address,omitempty"       jsonschema:"IPv4 address or CIDR (e.g. 192.168.1.10 or 192.168.1.10/24)"`
 		Netmask     string `json:"netmask,omitempty"       jsonschema:"IPv4 subnet mask"`
-		Gateway     string `json:"gateway,omitempty"       jsonschema:"default IPv4 gateway"`
-		Address6    string `json:"address6,omitempty"      jsonschema:"IPv6 address"`
-		Gateway6    string `json:"gateway6,omitempty"      jsonschema:"default IPv6 gateway"`
+		Gateway     string `json:"gateway,omitempty"       jsonschema:"default IPv4 gateway address"`
+		Address6    string `json:"address6,omitempty"      jsonschema:"IPv6 address or CIDR (e.g. 2001:db8::1 or 2001:db8::1/64)"`
+		Gateway6    string `json:"gateway6,omitempty"      jsonschema:"default IPv6 gateway address"`
 		MTU         int    `json:"mtu,omitempty"           jsonschema:"maximum transmission unit in bytes"`
-		Autostart   int    `json:"autostart,omitempty"     jsonschema:"1 to start on boot, 0 for manual"`
+		Autostart   *int   `json:"autostart,omitempty"     jsonschema:"1 to start on boot, 0 for manual; omit to leave unchanged"`
 		BridgePorts string `json:"bridge_ports,omitempty"  jsonschema:"space-separated list of bridge member ports (bridge type only)"`
 		BridgeSTP   string `json:"bridge_stp,omitempty"    jsonschema:"spanning tree protocol: on or off (bridge type only)"`
-		BridgeFD    int    `json:"bridge_fd,omitempty"     jsonschema:"bridge forward delay in seconds (bridge type only)"`
+		BridgeFD    *int   `json:"bridge_fd,omitempty"     jsonschema:"bridge forward delay in seconds (bridge type only); omit to leave unchanged"`
 		BondMode    string `json:"bond_mode,omitempty"     jsonschema:"bond mode: active-backup, 802.3ad, etc. (bond type only)"`
 		Slaves      string `json:"slaves,omitempty"        jsonschema:"space-separated bond member ports (bond type only)"`
 		Comments    string `json:"comments,omitempty"      jsonschema:"free-text comments; may include post-up/pre-down routing lines for static routes"`


### PR DESCRIPTION
## Summary

Closes #24

Adds write operations for Proxmox node network interfaces — create, update, apply staged changes, and delete. This is the Phase 8 toolset.

## New tools

| Tool | API endpoint | Type |
|---|---|---|
| `create_node_network_interface` | `POST /nodes/{node}/network` | always-on |
| `update_node_network_interface` | `PUT /nodes/{node}/network/{iface}` | always-on |
| `apply_node_network_changes` | `PUT /nodes/{node}/network` | always-on |
| `delete_node_network_interface` | `DELETE /nodes/{node}/network/{iface}` | destructive opt-in |

## Staging behaviour

All interface changes are written to `/etc/network/interfaces.new` on the node (staged). They have **no effect** until `apply_node_network_changes` is called, which reloads the network stack. The tool descriptions reflect this.

## Implementation notes

- `NetworkInterfaceConfig` struct in `internal/proxmox/network.go` covers bridge, bond, eth, alias, vlan, OVSBridge, OVSBond, OVSPort, and OVSIntPort interface types.
- `Autostart` and `BridgeFD` are `*int` so callers can explicitly send `0` (omitempty on `int` would silently drop it).
- `delete_node_network_interface` follows the 3-layer safety pattern: `PROXMOX_ALLOW_DESTRUCTIVE=true` + `confirmed: true` + `DestructiveHint`.
- `apply_node_network_changes` sends `{}` as the PUT body (the `put` helper always marshals); confirmed working against a live cluster.

## Testing

Tests added for all 4 new client methods:
- success case (with request body assertions for create, update, apply)
- notFound case
- apiError case (400/500)
- input validation (create + update)

`make check` passes: 0 lint issues, 0 security findings, all tests green.

## Tool count

76 → **80 tools** (73 always-on + 7 destructive opt-in)