### PR TITLE
fix: bump Go to 1.26.3 to resolve govulncheck findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gordcurrie/proxmox-mcp
 
-go 1.26.2
+go 1.26.3
 
 require github.com/modelcontextprotocol/go-sdk v1.4.1
 


### PR DESCRIPTION
## Summary

- Bumps `go` directive in `go.mod` from `1.26.2` → `1.26.3`
- Fixes two stdlib vulnerabilities identified by `govulncheck`:
  - **GO-2026-4971** — panic in `net.Dial`/`LookupPort` on NUL byte (Windows)
  - **GO-2026-4918** — infinite loop in `net/http` HTTP/2 transport on bad `SETTINGS_MAX_FRAME_SIZE`

## Test plan

- [x] `govulncheck ./...` — no vulnerabilities found
- [x] `make check` — all gates pass (fix, fmt, vet, lint, sec, vulncheck, test, build)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)