### PR TITLE
fix: bump Go to 1.26.4 and update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,11 +13,11 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
             goarch: amd64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -45,7 +45,7 @@ jobs:
             ./cmd/proxmox-mcp
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: proxmox-mcp_${{ matrix.goos }}_${{ matrix.goarch }}
           path: dist/proxmox-mcp_${{ matrix.goos }}_${{ matrix.goarch }}*
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist/
           merge-multiple: true

--- a/.github/workflows/test-latest.yml
+++ b/.github/workflows/test-latest.yml
@@ -13,11 +13,11 @@ jobs:
     name: test against latest deps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: false

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gordcurrie/proxmox-mcp
 
-go 1.26.3
+go 1.26.4
 
 require github.com/modelcontextprotocol/go-sdk v1.4.1
 


### PR DESCRIPTION
## Summary

- **go.mod**: `go 1.26.3` → `go 1.26.4` — fixes two stdlib CVEs flagged by govulncheck
  - `GO-2026-5039`: unescaped arbitrary inputs in `net/textproto`
  - `GO-2026-5037`: inefficient hostname parsing in `crypto/x509`
- **GitHub Actions**: updated all actions to Node.js 24 compatible versions ahead of the June 16 runner deadline
  - `actions/checkout`: v4 → v6
  - `actions/setup-go`: v5 → v6
  - `actions/upload-artifact`: v4 → v6
  - `actions/download-artifact`: v4 → v7

## Test plan

- [ ] govulncheck CI passes
- [ ] CI (make check) passes
- [ ] No Node.js 20 deprecation warnings in any workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)