### PR TITLE
fix: bump Go to 1.26.5 to resolve govulncheck GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gordcurrie/proxmox-mcp
 
-go 1.26.4
+go 1.26.5
 
 require github.com/modelcontextprotocol/go-sdk v1.4.1
 


### PR DESCRIPTION
## Summary
- Scheduled govulncheck run failed: GO-2026-5856 (crypto/tls ECH privacy leak), reachable via TLS calls in `main.go` and `internal/proxmox/client.go`
- Fixed upstream in go1.26.5; bumps `go.mod` accordingly

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `govulncheck ./...` — 0 vulnerabilities