### PR TITLE
Add access-control audit tools (list_users, list_user_tokens, get_node_journal)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -15,6 +15,7 @@ linting via `golangci-lint`/`gosec`/`govulncheck`.
 | 8 — Network Write Operations | ✅ Complete — 80 tools (PR #25) |
 | Token optimisation | ✅ Complete — compact JSON responses, selective `omitempty` (PR #29) |
 | Quality Parity with unifi-mcp | ✅ Complete — hardening, CI workflows, interface + tests (PR #32) |
+| Access Control & Audit Tools | ✅ Complete — 83 tools: `list_users`, `list_user_tokens`, `get_node_journal` (PR #34) |
 
 ## Decisions
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 | `list_node_storage` | Storage pools available on a node | `node` |
 | `list_node_tasks` | Recent tasks on a node | `node`, `limit` (optional) |
 | `get_node_disks` | Physical disks detected on a node | `node` |
+| `get_node_journal` | Raw systemd journal entries for a node (e.g. auditing SSH/PAM auth activity) | `node`, `since` (optional, Unix timestamp), `until` (optional, Unix timestamp), `last_entries` (optional) |
 
 ### QEMU VMs
 
@@ -125,6 +126,13 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 | `get_storage` | Get full configuration of a storage definition | `storage` (name) |
 | `add_storage` | Add a new storage target to the cluster | `storage` (name), `type` (required: `nfs`\|`pbs`\|`dir`\|`cifs`\|`zfspool`\|...), `server` (optional), `export` (optional, NFS path), `path` (optional, dir path), `datastore` (optional, PBS datastore), `username` (optional), `password` (optional), `fingerprint` (optional, PBS TLS fingerprint), `content` (optional, e.g. `backup,images`), `nodes` (optional, comma-sep), `shared` (optional bool) |
 | `update_storage` | Update an existing storage definition | `storage` (name), plus any of: `server`, `export`, `path`, `datastore`, `username`, `password`, `fingerprint`, `content`, `nodes`, `shared` |
+
+### Access Control
+
+| Tool | Description | Parameters |
+|---|---|---|
+| `list_users` | List all users across all realms (pve, pam, ldap, etc) — audit for unrecognized or orphaned accounts | — |
+| `list_user_tokens` | List API tokens issued to a user (metadata only, secrets are never returned) | `userid` (e.g. `root@pam`) |
 
 ### Destructive (opt-in)
 

--- a/internal/proxmox/access.go
+++ b/internal/proxmox/access.go
@@ -1,0 +1,29 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// ListUsers returns all users configured in the Proxmox access control
+// system, across all realms (pve, pam, ldap, etc). Useful for auditing for
+// unrecognized or orphaned accounts.
+func (c *Client) ListUsers(ctx context.Context) ([]map[string]any, error) {
+	var users []map[string]any
+	if err := c.get(ctx, "/access/users", &users); err != nil {
+		return nil, fmt.Errorf("listing users: %w", err)
+	}
+	return users, nil
+}
+
+// ListUserTokens returns the API tokens issued to a single user. Token
+// secrets are never included by the Proxmox API — only metadata (token ID,
+// comment, expiry, privilege separation).
+func (c *Client) ListUserTokens(ctx context.Context, userid string) ([]map[string]any, error) {
+	var tokens []map[string]any
+	if err := c.get(ctx, "/access/users/"+url.PathEscape(userid)+"/token", &tokens); err != nil {
+		return nil, fmt.Errorf("listing tokens for user %s: %w", userid, err)
+	}
+	return tokens, nil
+}

--- a/internal/proxmox/access_test.go
+++ b/internal/proxmox/access_test.go
@@ -1,0 +1,91 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListUsers_success(t *testing.T) {
+	t.Parallel()
+
+	want := []map[string]any{
+		{"userid": "root@pam", "enable": float64(1)},
+		{"userid": "gord@pve", "enable": float64(1)},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/access/users" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListUsers(context.Background())
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d users, want 2", len(got))
+	}
+	if got[0]["userid"] != "root@pam" {
+		t.Errorf("user[0]: got %v, want root@pam", got[0]["userid"])
+	}
+}
+
+func TestListUsers_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).ListUsers(context.Background())
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestListUserTokens_success(t *testing.T) {
+	t.Parallel()
+
+	want := []map[string]any{
+		{"tokenid": "mcp", "comment": "MCP server token"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/access/users/root@pam/token" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListUserTokens(context.Background(), "root@pam")
+	if err != nil {
+		t.Fatalf("ListUserTokens: %v", err)
+	}
+	if len(got) != 1 || got[0]["tokenid"] != "mcp" {
+		t.Errorf("got %+v, want 1 token with tokenid mcp", got)
+	}
+}
+
+func TestListUserTokens_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).ListUserTokens(context.Background(), "nobody@pam")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/proxmox/nodes.go
+++ b/internal/proxmox/nodes.go
@@ -62,6 +62,42 @@ func (c *Client) GetNodeDisks(ctx context.Context, node string) ([]map[string]an
 	return disks, nil
 }
 
+// GetNodeJournal returns raw systemd journal entries for a node — the same
+// data backing the Proxmox web UI's Syslog viewer. Useful for auditing
+// SSH/PAM authentication activity (grep client-side for "sshd",
+// "Failed password", "Invalid user", etc) or general troubleshooting.
+//
+// since and until are Unix timestamps; pass 0 to omit either bound.
+// lastEntries limits the result to the last N entries; pass 0 to use the
+// Proxmox API default. A negative lastEntries is an error.
+func (c *Client) GetNodeJournal(ctx context.Context, node string, since, until int64, lastEntries int) ([]string, error) {
+	if lastEntries < 0 {
+		return nil, fmt.Errorf("lastEntries must be >= 0, got %d", lastEntries)
+	}
+
+	q := url.Values{}
+	if since > 0 {
+		q.Set("since", strconv.FormatInt(since, 10))
+	}
+	if until > 0 {
+		q.Set("until", strconv.FormatInt(until, 10))
+	}
+	if lastEntries > 0 {
+		q.Set("lastentries", strconv.Itoa(lastEntries))
+	}
+
+	path := "/nodes/" + url.PathEscape(node) + "/journal"
+	if enc := q.Encode(); enc != "" {
+		path += "?" + enc
+	}
+
+	var lines []string
+	if err := c.get(ctx, path, &lines); err != nil {
+		return nil, fmt.Errorf("getting journal for node %s: %w", node, err)
+	}
+	return lines, nil
+}
+
 // NodeCommand sends a power management command to a node.
 // command must be "reboot" or "shutdown". The operation is irreversible and
 // takes down the entire node, so callers must validate before invoking this.

--- a/internal/proxmox/nodes.go
+++ b/internal/proxmox/nodes.go
@@ -71,6 +71,15 @@ func (c *Client) GetNodeDisks(ctx context.Context, node string) ([]map[string]an
 // lastEntries limits the result to the last N entries; pass 0 to use the
 // Proxmox API default. A negative lastEntries is an error.
 func (c *Client) GetNodeJournal(ctx context.Context, node string, since, until int64, lastEntries int) ([]string, error) {
+	if since < 0 {
+		return nil, fmt.Errorf("since must be >= 0, got %d", since)
+	}
+	if until < 0 {
+		return nil, fmt.Errorf("until must be >= 0, got %d", until)
+	}
+	if since > 0 && until > 0 && since > until {
+		return nil, fmt.Errorf("since (%d) must be <= until (%d)", since, until)
+	}
 	if lastEntries < 0 {
 		return nil, fmt.Errorf("lastEntries must be >= 0, got %d", lastEntries)
 	}

--- a/internal/proxmox/nodes_test.go
+++ b/internal/proxmox/nodes_test.go
@@ -260,7 +260,7 @@ func TestGetNodeJournal_success(t *testing.T) {
 	t.Parallel()
 
 	want := []string{
-		"Aug 07 11:30:38 pve1 sshd-session[26013]: Invalid user gcurrie from 192.168.1.209 port 55009",
+		"Aug 07 11:30:38 pve1 sshd-session[26013]: Invalid user testuser from 192.0.2.10 port 55009",
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/nodes/pve1/journal" {
@@ -315,6 +315,45 @@ func TestGetNodeJournal_negativeLastEntriesError(t *testing.T) {
 	_, err := c.GetNodeJournal(context.Background(), "pve1", 0, 0, -1)
 	if err == nil {
 		t.Fatal("expected error for negative lastEntries, got nil")
+	}
+}
+
+func TestGetNodeJournal_negativeSinceError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, err := c.GetNodeJournal(context.Background(), "pve1", -1, 0, 0)
+	if err == nil {
+		t.Fatal("expected error for negative since, got nil")
+	}
+}
+
+func TestGetNodeJournal_negativeUntilError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, err := c.GetNodeJournal(context.Background(), "pve1", 0, -1, 0)
+	if err == nil {
+		t.Fatal("expected error for negative until, got nil")
+	}
+}
+
+func TestGetNodeJournal_sinceAfterUntilError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, err := c.GetNodeJournal(context.Background(), "pve1", 200, 100, 0)
+	if err == nil {
+		t.Fatal("expected error for since > until, got nil")
 	}
 }
 

--- a/internal/proxmox/nodes_test.go
+++ b/internal/proxmox/nodes_test.go
@@ -256,6 +256,82 @@ func TestGetNodeDisks_notFound(t *testing.T) {
 	}
 }
 
+func TestGetNodeJournal_success(t *testing.T) {
+	t.Parallel()
+
+	want := []string{
+		"Aug 07 11:30:38 pve1 sshd-session[26013]: Invalid user gcurrie from 192.168.1.209 port 55009",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nodes/pve1/journal" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).GetNodeJournal(context.Background(), "pve1", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("GetNodeJournal: %v", err)
+	}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestGetNodeJournal_withParams(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nodes/pve1/journal" {
+			http.NotFound(w, r)
+			return
+		}
+		q := r.URL.Query()
+		if q.Get("since") != "100" || q.Get("until") != "200" || q.Get("lastentries") != "50" {
+			http.Error(w, "missing query params: "+q.Encode(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, []string{}))
+	}))
+	defer srv.Close()
+
+	if _, err := newTestClient(t, srv.URL).GetNodeJournal(context.Background(), "pve1", 100, 200, 50); err != nil {
+		t.Fatalf("GetNodeJournal with params: %v", err)
+	}
+}
+
+func TestGetNodeJournal_negativeLastEntriesError(t *testing.T) {
+	t.Parallel()
+
+	// The error is returned before any HTTP call; the server is never contacted.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, err := c.GetNodeJournal(context.Background(), "pve1", 0, 0, -1)
+	if err == nil {
+		t.Fatal("expected error for negative lastEntries, got nil")
+	}
+}
+
+func TestGetNodeJournal_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).GetNodeJournal(context.Background(), "missing", 0, 0, 0)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
 func TestNodeCommand_success(t *testing.T) {
 	t.Parallel()
 

--- a/tools/access.go
+++ b/tools/access.go
@@ -1,0 +1,39 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registerAccessTools adds user/token audit MCP tools to the server.
+func registerAccessTools(s *mcp.Server, client proxmoxClient) {
+	type listUsersInput struct{}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_users",
+		Description: "List all users configured in Proxmox access control, across all realms (pve, pam, ldap, etc). Use to audit for unrecognized or orphaned accounts.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listUsersInput) (*mcp.CallToolResult, any, error) {
+		users, err := client.ListUsers(ctx)
+		if err != nil {
+			return errorResult(fmt.Errorf("list_users: %w", err))
+		}
+		return jsonResult(users)
+	})
+
+	type listUserTokensInput struct {
+		UserID string `json:"userid" jsonschema:"full user ID including realm, e.g. root@pam"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_user_tokens",
+		Description: "List API tokens issued to a Proxmox user. Token secrets are never returned, only metadata (token ID, comment, expiry).",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input listUserTokensInput) (*mcp.CallToolResult, any, error) {
+		tokens, err := client.ListUserTokens(ctx, input.UserID)
+		if err != nil {
+			return errorResult(fmt.Errorf("list_user_tokens: %w", err))
+		}
+		return jsonResult(tokens)
+	})
+}

--- a/tools/access_test.go
+++ b/tools/access_test.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestListUsers(t *testing.T) {
+	t.Run("returns users as JSON", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listUsersFn: func(context.Context) ([]map[string]any, error) {
+				return []map[string]any{{"userid": "root@pam", "enable": 1}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_users", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listUsersFn: func(context.Context) ([]map[string]any, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_users", nil)
+		assertError(t, res, "API error")
+	})
+}
+
+func TestListUserTokens(t *testing.T) {
+	t.Run("returns tokens as JSON", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listUserTokensFn: func(_ context.Context, userid string) ([]map[string]any, error) {
+				return []map[string]any{{"tokenid": "mcp", "userid": userid}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_user_tokens", map[string]any{"userid": "root@pam"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listUserTokensFn: func(context.Context, string) ([]map[string]any, error) {
+				return nil, errors.New("user not found")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_user_tokens", map[string]any{"userid": "nobody@pam"})
+		assertError(t, res, "user not found")
+	})
+}

--- a/tools/client_iface.go
+++ b/tools/client_iface.go
@@ -16,6 +16,7 @@ type proxmoxClient interface {
 	ListNodeStorage(ctx context.Context, node string) ([]map[string]any, error)
 	ListNodeTasks(ctx context.Context, node string, limit int) ([]map[string]any, error)
 	GetNodeDisks(ctx context.Context, node string) ([]map[string]any, error)
+	GetNodeJournal(ctx context.Context, node string, since, until int64, lastEntries int) ([]string, error)
 	NodeCommand(ctx context.Context, node, command string) error
 
 	// VMs
@@ -110,4 +111,8 @@ type proxmoxClient interface {
 	CreatePool(ctx context.Context, req *proxmox.CreatePoolRequest) error
 	UpdatePool(ctx context.Context, poolid string, req *proxmox.UpdatePoolRequest) error
 	DeletePool(ctx context.Context, poolid string) error
+
+	// Access control
+	ListUsers(ctx context.Context) ([]map[string]any, error)
+	ListUserTokens(ctx context.Context, userid string) ([]map[string]any, error)
 }

--- a/tools/mock_client_test.go
+++ b/tools/mock_client_test.go
@@ -16,6 +16,7 @@ type mockProxmoxClient struct {
 	listNodeStorageFn func(context.Context, string) ([]map[string]any, error)
 	listNodeTasksFn   func(context.Context, string, int) ([]map[string]any, error)
 	getNodeDisksFn    func(context.Context, string) ([]map[string]any, error)
+	getNodeJournalFn  func(context.Context, string, int64, int64, int) ([]string, error)
 	nodeCommandFn     func(context.Context, string, string) error
 
 	// VMs
@@ -110,6 +111,10 @@ type mockProxmoxClient struct {
 	createPoolFn func(context.Context, *proxmox.CreatePoolRequest) error
 	updatePoolFn func(context.Context, string, *proxmox.UpdatePoolRequest) error
 	deletePoolFn func(context.Context, string) error
+
+	// Access control
+	listUsersFn      func(context.Context) ([]map[string]any, error)
+	listUserTokensFn func(context.Context, string) ([]map[string]any, error)
 }
 
 // Nodes
@@ -145,6 +150,13 @@ func (m *mockProxmoxClient) ListNodeTasks(ctx context.Context, node string, limi
 func (m *mockProxmoxClient) GetNodeDisks(ctx context.Context, node string) ([]map[string]any, error) {
 	if m.getNodeDisksFn != nil {
 		return m.getNodeDisksFn(ctx, node)
+	}
+	return nil, nil
+}
+
+func (m *mockProxmoxClient) GetNodeJournal(ctx context.Context, node string, since, until int64, lastEntries int) ([]string, error) {
+	if m.getNodeJournalFn != nil {
+		return m.getNodeJournalFn(ctx, node, since, until, lastEntries)
 	}
 	return nil, nil
 }
@@ -685,4 +697,20 @@ func (m *mockProxmoxClient) DeletePool(ctx context.Context, poolid string) error
 		return m.deletePoolFn(ctx, poolid)
 	}
 	return nil
+}
+
+// Access control
+
+func (m *mockProxmoxClient) ListUsers(ctx context.Context) ([]map[string]any, error) {
+	if m.listUsersFn != nil {
+		return m.listUsersFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockProxmoxClient) ListUserTokens(ctx context.Context, userid string) ([]map[string]any, error) {
+	if m.listUserTokensFn != nil {
+		return m.listUserTokensFn(ctx, userid)
+	}
+	return nil, nil
 }

--- a/tools/nodes.go
+++ b/tools/nodes.go
@@ -79,4 +79,25 @@ func registerNodeTools(s *mcp.Server, client proxmoxClient) {
 		}
 		return jsonResult(disks)
 	})
+
+	type getNodeJournalInput struct {
+		Node        string `json:"node"                    jsonschema:"name of the node"`
+		Since       int64  `json:"since,omitempty"         jsonschema:"only return entries at or after this Unix timestamp (0 = no lower bound)"`
+		Until       int64  `json:"until,omitempty"         jsonschema:"only return entries at or before this Unix timestamp (0 = no upper bound)"`
+		LastEntries int    `json:"last_entries,omitempty"  jsonschema:"limit to the last N entries (0 = Proxmox API default)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_node_journal",
+		Description: "Get raw systemd journal entries for a Proxmox node — the same data behind the web UI's Syslog viewer. Useful for auditing SSH/PAM authentication activity (look for 'sshd', 'Failed password', 'Invalid user', etc) or general troubleshooting.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input getNodeJournalInput) (*mcp.CallToolResult, any, error) {
+		if input.LastEntries < 0 {
+			return errorResult(fmt.Errorf("get_node_journal: last_entries must be >= 0, got %d", input.LastEntries))
+		}
+		lines, err := client.GetNodeJournal(ctx, input.Node, input.Since, input.Until, input.LastEntries)
+		if err != nil {
+			return errorResult(fmt.Errorf("get_node_journal: %w", err))
+		}
+		return jsonResult(lines)
+	})
 }

--- a/tools/nodes.go
+++ b/tools/nodes.go
@@ -91,6 +91,15 @@ func registerNodeTools(s *mcp.Server, client proxmoxClient) {
 		Description: "Get raw systemd journal entries for a Proxmox node — the same data behind the web UI's Syslog viewer. Useful for auditing SSH/PAM authentication activity (look for 'sshd', 'Failed password', 'Invalid user', etc) or general troubleshooting.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, input getNodeJournalInput) (*mcp.CallToolResult, any, error) {
+		if input.Since < 0 {
+			return errorResult(fmt.Errorf("get_node_journal: since must be >= 0, got %d", input.Since))
+		}
+		if input.Until < 0 {
+			return errorResult(fmt.Errorf("get_node_journal: until must be >= 0, got %d", input.Until))
+		}
+		if input.Since > 0 && input.Until > 0 && input.Since > input.Until {
+			return errorResult(fmt.Errorf("get_node_journal: since (%d) must be <= until (%d)", input.Since, input.Until))
+		}
 		if input.LastEntries < 0 {
 			return errorResult(fmt.Errorf("get_node_journal: last_entries must be >= 0, got %d", input.LastEntries))
 		}

--- a/tools/nodes_test.go
+++ b/tools/nodes_test.go
@@ -119,7 +119,7 @@ func TestGetNodeJournal(t *testing.T) {
 	t.Run("returns journal lines as JSON", func(t *testing.T) {
 		mock := &mockProxmoxClient{
 			getNodeJournalFn: func(context.Context, string, int64, int64, int) ([]string, error) {
-				return []string{"Aug 07 11:30:38 pve1 sshd-session[26013]: Invalid user gcurrie"}, nil
+				return []string{"Aug 07 11:30:38 pve1 sshd-session[26013]: Invalid user testuser"}, nil
 			},
 		}
 		cs, cleanup := connectTestServer(t, mock)
@@ -135,6 +135,30 @@ func TestGetNodeJournal(t *testing.T) {
 
 		res := callTool(t, cs, "get_node_journal", map[string]any{"node": "pve1", "last_entries": -1})
 		assertError(t, res, "last_entries must be >= 0")
+	})
+
+	t.Run("rejects negative since", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockProxmoxClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "get_node_journal", map[string]any{"node": "pve1", "since": -1})
+		assertError(t, res, "since must be >= 0")
+	})
+
+	t.Run("rejects negative until", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockProxmoxClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "get_node_journal", map[string]any{"node": "pve1", "until": -1})
+		assertError(t, res, "until must be >= 0")
+	})
+
+	t.Run("rejects since after until", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockProxmoxClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "get_node_journal", map[string]any{"node": "pve1", "since": 200, "until": 100})
+		assertError(t, res, "must be <= until")
 	})
 
 	t.Run("propagates error", func(t *testing.T) {

--- a/tools/nodes_test.go
+++ b/tools/nodes_test.go
@@ -114,3 +114,39 @@ func TestGetNodeDisks(t *testing.T) {
 		assertError(t, res, "disk enumeration failed")
 	})
 }
+
+func TestGetNodeJournal(t *testing.T) {
+	t.Run("returns journal lines as JSON", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			getNodeJournalFn: func(context.Context, string, int64, int64, int) ([]string, error) {
+				return []string{"Aug 07 11:30:38 pve1 sshd-session[26013]: Invalid user gcurrie"}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_node_journal", map[string]any{"node": "pve1", "last_entries": 50})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("rejects negative last_entries", func(t *testing.T) {
+		cs, cleanup := connectTestServer(t, &mockProxmoxClient{})
+		defer cleanup()
+
+		res := callTool(t, cs, "get_node_journal", map[string]any{"node": "pve1", "last_entries": -1})
+		assertError(t, res, "last_entries must be >= 0")
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			getNodeJournalFn: func(context.Context, string, int64, int64, int) ([]string, error) {
+				return nil, errors.New("journal unavailable")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_node_journal", map[string]any{"node": "pve1"})
+		assertError(t, res, "journal unavailable")
+	})
+}

--- a/tools/register.go
+++ b/tools/register.go
@@ -26,6 +26,7 @@ func RegisterAll(s *mcp.Server, client proxmoxClient, cfg Config) {
 	registerFirewallTools(s, client)
 	registerPoolTools(s, client)
 	registerStorageDefTools(s, client)
+	registerAccessTools(s, client)
 	if cfg.AllowDestructive {
 		registerDestructiveTools(s, client)
 	}


### PR DESCRIPTION
## Summary
- Add `list_users` / `list_user_tokens` — wraps `GET /access/users` and `GET /access/users/{id}/token` for auditing Proxmox accounts and API tokens (no secrets returned)
- Add `get_node_journal` — wraps `GET /nodes/{node}/journal` (same data as the web UI's Syslog viewer) for reviewing SSH/PAM auth activity without SSH access
- All three tools are read-only, registered unconditionally like the rest of the list/get tools

Prompted by a homelab security audit that had to fall back to raw SSH (`pveum user list`, `journalctl`) because no MCP tool covered user/token inventory or auth-log review.

**Note:** `GET /access/users` and the journal endpoint are typically gated behind `Sys.Audit`/admin-level privilege in Proxmox's ACL system — a narrowly-scoped token may need its role expanded to call these.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — no issues
- [x] `go test ./...` — 352 passed
- [ ] Verify against a live cluster once the MCP token's role covers `Sys.Audit`