### PR TITLE
Add ZFS pool and disk SMART health tools

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -16,6 +16,7 @@ linting via `golangci-lint`/`gosec`/`govulncheck`.
 | Token optimisation | ✅ Complete — compact JSON responses, selective `omitempty` (PR #29) |
 | Quality Parity with unifi-mcp | ✅ Complete — hardening, CI workflows, interface + tests (PR #32) |
 | Access Control & Audit Tools | ✅ Complete — 83 tools: `list_users`, `list_user_tokens`, `get_node_journal` (PR #34) |
+| Disk Health Tools | ✅ Complete — 86 tools: `get_disk_smart`, `list_zfs_pools`, `get_zfs_pool` (PR #35) |
 
 ## Decisions
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 | `list_node_storage` | Storage pools available on a node | `node` |
 | `list_node_tasks` | Recent tasks on a node | `node`, `limit` (optional) |
 | `get_node_disks` | Physical disks detected on a node | `node` |
+| `get_disk_smart` | SMART health data for a single disk (attributes, health, error counters) | `node`, `disk` (device path, e.g. `/dev/sda`) |
+| `list_zfs_pools` | List all ZFS pools on a node with health status | `node` |
+| `get_zfs_pool` | Detailed ZFS pool status including per-device health (like `zpool status -v`) | `node`, `name` (pool name) |
 | `get_node_journal` | Raw systemd journal entries for a node (e.g. auditing SSH/PAM auth activity) | `node`, `since` (optional, Unix timestamp), `until` (optional, Unix timestamp), `last_entries` (optional) |
 
 ### QEMU VMs

--- a/internal/proxmox/nodes.go
+++ b/internal/proxmox/nodes.go
@@ -62,6 +62,37 @@ func (c *Client) GetNodeDisks(ctx context.Context, node string) ([]map[string]an
 	return disks, nil
 }
 
+// GetDiskSMART returns SMART health data for a single disk on a node, as
+// reported by `smartctl` via the Proxmox API. disk must be the device path
+// (e.g. "/dev/sda") as returned by GetNodeDisks.
+func (c *Client) GetDiskSMART(ctx context.Context, node, disk string) (map[string]any, error) {
+	var smart map[string]any
+	path := "/nodes/" + url.PathEscape(node) + "/disks/smart?disk=" + url.QueryEscape(disk)
+	if err := c.get(ctx, path, &smart); err != nil {
+		return nil, fmt.Errorf("getting SMART data for disk %s on node %s: %w", disk, node, err)
+	}
+	return smart, nil
+}
+
+// ListZFSPools returns all ZFS pools on a node, including health status.
+func (c *Client) ListZFSPools(ctx context.Context, node string) ([]map[string]any, error) {
+	var pools []map[string]any
+	if err := c.get(ctx, "/nodes/"+url.PathEscape(node)+"/disks/zfs", &pools); err != nil {
+		return nil, fmt.Errorf("listing ZFS pools on node %s: %w", node, err)
+	}
+	return pools, nil
+}
+
+// GetZFSPool returns detailed status for a single ZFS pool on a node,
+// including per-device health (the equivalent of `zpool status -v`).
+func (c *Client) GetZFSPool(ctx context.Context, node, name string) (map[string]any, error) {
+	var pool map[string]any
+	if err := c.get(ctx, "/nodes/"+url.PathEscape(node)+"/disks/zfs/"+url.PathEscape(name), &pool); err != nil {
+		return nil, fmt.Errorf("getting ZFS pool %s on node %s: %w", name, node, err)
+	}
+	return pool, nil
+}
+
 // GetNodeJournal returns raw systemd journal entries for a node — the same
 // data backing the Proxmox web UI's Syslog viewer. Useful for auditing
 // SSH/PAM authentication activity (grep client-side for "sshd",

--- a/internal/proxmox/nodes.go
+++ b/internal/proxmox/nodes.go
@@ -67,7 +67,9 @@ func (c *Client) GetNodeDisks(ctx context.Context, node string) ([]map[string]an
 // (e.g. "/dev/sda") as returned by GetNodeDisks.
 func (c *Client) GetDiskSMART(ctx context.Context, node, disk string) (map[string]any, error) {
 	var smart map[string]any
-	path := "/nodes/" + url.PathEscape(node) + "/disks/smart?disk=" + url.QueryEscape(disk)
+	q := url.Values{}
+	q.Set("disk", disk)
+	path := "/nodes/" + url.PathEscape(node) + "/disks/smart?" + q.Encode()
 	if err := c.get(ctx, path, &smart); err != nil {
 		return nil, fmt.Errorf("getting SMART data for disk %s on node %s: %w", disk, node, err)
 	}

--- a/internal/proxmox/nodes_test.go
+++ b/internal/proxmox/nodes_test.go
@@ -256,6 +256,119 @@ func TestGetNodeDisks_notFound(t *testing.T) {
 	}
 }
 
+func TestGetDiskSMART_success(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]any{"health": "PASSED", "type": "ata"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nodes/pve1/disks/smart" || r.URL.Query().Get("disk") != "/dev/sda" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).GetDiskSMART(context.Background(), "pve1", "/dev/sda")
+	if err != nil {
+		t.Fatalf("GetDiskSMART: %v", err)
+	}
+	if got["health"] != "PASSED" {
+		t.Errorf("health: got %v, want PASSED", got["health"])
+	}
+}
+
+func TestGetDiskSMART_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).GetDiskSMART(context.Background(), "pve1", "/dev/missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestListZFSPools_success(t *testing.T) {
+	t.Parallel()
+
+	want := []map[string]any{
+		{"name": "Storage", "health": "DEGRADED", "size": float64(1000204886016)},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nodes/pve2/disks/zfs" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListZFSPools(context.Background(), "pve2")
+	if err != nil {
+		t.Fatalf("ListZFSPools: %v", err)
+	}
+	if len(got) != 1 || got[0]["name"] != "Storage" {
+		t.Errorf("got %+v, want 1 pool named Storage", got)
+	}
+}
+
+func TestListZFSPools_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).ListZFSPools(context.Background(), "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetZFSPool_success(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]any{"name": "Storage", "state": "DEGRADED"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nodes/pve2/disks/zfs/Storage" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).GetZFSPool(context.Background(), "pve2", "Storage")
+	if err != nil {
+		t.Fatalf("GetZFSPool: %v", err)
+	}
+	if got["state"] != "DEGRADED" {
+		t.Errorf("state: got %v, want DEGRADED", got["state"])
+	}
+}
+
+func TestGetZFSPool_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).GetZFSPool(context.Background(), "pve2", "NoSuchPool")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
 func TestGetNodeJournal_success(t *testing.T) {
 	t.Parallel()
 

--- a/tools/client_iface.go
+++ b/tools/client_iface.go
@@ -16,6 +16,9 @@ type proxmoxClient interface {
 	ListNodeStorage(ctx context.Context, node string) ([]map[string]any, error)
 	ListNodeTasks(ctx context.Context, node string, limit int) ([]map[string]any, error)
 	GetNodeDisks(ctx context.Context, node string) ([]map[string]any, error)
+	GetDiskSMART(ctx context.Context, node, disk string) (map[string]any, error)
+	ListZFSPools(ctx context.Context, node string) ([]map[string]any, error)
+	GetZFSPool(ctx context.Context, node, name string) (map[string]any, error)
 	GetNodeJournal(ctx context.Context, node string, since, until int64, lastEntries int) ([]string, error)
 	NodeCommand(ctx context.Context, node, command string) error
 

--- a/tools/mock_client_test.go
+++ b/tools/mock_client_test.go
@@ -16,6 +16,9 @@ type mockProxmoxClient struct {
 	listNodeStorageFn func(context.Context, string) ([]map[string]any, error)
 	listNodeTasksFn   func(context.Context, string, int) ([]map[string]any, error)
 	getNodeDisksFn    func(context.Context, string) ([]map[string]any, error)
+	getDiskSMARTFn    func(context.Context, string, string) (map[string]any, error)
+	listZFSPoolsFn    func(context.Context, string) ([]map[string]any, error)
+	getZFSPoolFn      func(context.Context, string, string) (map[string]any, error)
 	getNodeJournalFn  func(context.Context, string, int64, int64, int) ([]string, error)
 	nodeCommandFn     func(context.Context, string, string) error
 
@@ -150,6 +153,27 @@ func (m *mockProxmoxClient) ListNodeTasks(ctx context.Context, node string, limi
 func (m *mockProxmoxClient) GetNodeDisks(ctx context.Context, node string) ([]map[string]any, error) {
 	if m.getNodeDisksFn != nil {
 		return m.getNodeDisksFn(ctx, node)
+	}
+	return nil, nil
+}
+
+func (m *mockProxmoxClient) GetDiskSMART(ctx context.Context, node, disk string) (map[string]any, error) {
+	if m.getDiskSMARTFn != nil {
+		return m.getDiskSMARTFn(ctx, node, disk)
+	}
+	return nil, nil
+}
+
+func (m *mockProxmoxClient) ListZFSPools(ctx context.Context, node string) ([]map[string]any, error) {
+	if m.listZFSPoolsFn != nil {
+		return m.listZFSPoolsFn(ctx, node)
+	}
+	return nil, nil
+}
+
+func (m *mockProxmoxClient) GetZFSPool(ctx context.Context, node, name string) (map[string]any, error) {
+	if m.getZFSPoolFn != nil {
+		return m.getZFSPoolFn(ctx, node, name)
 	}
 	return nil, nil
 }

--- a/tools/nodes.go
+++ b/tools/nodes.go
@@ -80,6 +80,50 @@ func registerNodeTools(s *mcp.Server, client proxmoxClient) {
 		return jsonResult(disks)
 	})
 
+	type getDiskSMARTInput struct {
+		Node string `json:"node" jsonschema:"name of the node"`
+		Disk string `json:"disk" jsonschema:"device path of the disk, e.g. /dev/sda (as returned by get_node_disks)"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_disk_smart",
+		Description: "Get SMART health data for a single disk on a node (attributes, health status, error counters).",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input getDiskSMARTInput) (*mcp.CallToolResult, any, error) {
+		smart, err := client.GetDiskSMART(ctx, input.Node, input.Disk)
+		if err != nil {
+			return errorResult(fmt.Errorf("get_disk_smart: %w", err))
+		}
+		return jsonResult(smart)
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_zfs_pools",
+		Description: "List all ZFS pools on a node, including health status.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input nodeInput) (*mcp.CallToolResult, any, error) {
+		pools, err := client.ListZFSPools(ctx, input.Node)
+		if err != nil {
+			return errorResult(fmt.Errorf("list_zfs_pools: %w", err))
+		}
+		return jsonResult(pools)
+	})
+
+	type getZFSPoolInput struct {
+		Node string `json:"node" jsonschema:"name of the node"`
+		Name string `json:"name" jsonschema:"name of the ZFS pool, e.g. Storage"`
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_zfs_pool",
+		Description: "Get detailed status for a single ZFS pool on a node, including per-device health — the equivalent of 'zpool status -v'.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input getZFSPoolInput) (*mcp.CallToolResult, any, error) {
+		pool, err := client.GetZFSPool(ctx, input.Node, input.Name)
+		if err != nil {
+			return errorResult(fmt.Errorf("get_zfs_pool: %w", err))
+		}
+		return jsonResult(pool)
+	})
+
 	type getNodeJournalInput struct {
 		Node        string `json:"node"                    jsonschema:"name of the node"`
 		Since       int64  `json:"since,omitempty"         jsonschema:"only return entries at or after this Unix timestamp (0 = no lower bound)"`

--- a/tools/nodes_test.go
+++ b/tools/nodes_test.go
@@ -115,6 +115,90 @@ func TestGetNodeDisks(t *testing.T) {
 	})
 }
 
+func TestGetDiskSMART(t *testing.T) {
+	t.Run("returns SMART data as JSON", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			getDiskSMARTFn: func(context.Context, string, string) (map[string]any, error) {
+				return map[string]any{"health": "PASSED"}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_disk_smart", map[string]any{"node": "pve1", "disk": "/dev/sda"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			getDiskSMARTFn: func(context.Context, string, string) (map[string]any, error) {
+				return nil, errors.New("disk not found")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_disk_smart", map[string]any{"node": "pve1", "disk": "/dev/missing"})
+		assertError(t, res, "disk not found")
+	})
+}
+
+func TestListZFSPools(t *testing.T) {
+	t.Run("returns pools as JSON", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listZFSPoolsFn: func(context.Context, string) ([]map[string]any, error) {
+				return []map[string]any{{"name": "Storage", "health": "ONLINE"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_zfs_pools", map[string]any{"node": "pve1"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listZFSPoolsFn: func(context.Context, string) ([]map[string]any, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_zfs_pools", map[string]any{"node": "pve1"})
+		assertError(t, res, "API error")
+	})
+}
+
+func TestGetZFSPool(t *testing.T) {
+	t.Run("returns pool as JSON", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			getZFSPoolFn: func(_ context.Context, _, name string) (map[string]any, error) {
+				return map[string]any{"name": name, "state": "DEGRADED"}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_zfs_pool", map[string]any{"node": "pve2", "name": "Storage"})
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			getZFSPoolFn: func(context.Context, string, string) (map[string]any, error) {
+				return nil, errors.New("pool not found")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_zfs_pool", map[string]any{"node": "pve2", "name": "NoSuch"})
+		assertError(t, res, "pool not found")
+	})
+}
+
 func TestGetNodeJournal(t *testing.T) {
 	t.Run("returns journal lines as JSON", func(t *testing.T) {
 		mock := &mockProxmoxClient{


### PR DESCRIPTION
## Summary
- Add `get_disk_smart` — wraps `GET /nodes/{node}/disks/smart?disk=X`, returns SMART attributes/health for a single disk
- Add `list_zfs_pools` — wraps `GET /nodes/{node}/disks/zfs`, lists ZFS pools with health status
- Add `get_zfs_pool` — wraps `GET /nodes/{node}/disks/zfs/{name}`, per-device detail equivalent to `zpool status -v`
- All three are read-only, registered unconditionally alongside the existing node/disk tools

Prompted by diagnosing a DEGRADED ZFS pool on pve2 (intermittent SATA link
resets from a loose cable/connector) — the whole investigation needed raw
SSH + `zpool status` + `smartctl` even though Proxmox exposes both natively.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — no issues
- [x] `go test ./...` — 373 passed
- [ ] Verify against a live cluster (pve2's `Storage` pool is a good real-world DEGRADED test case right now)