### PR TITLE
Add HA and cluster config visibility tools

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -17,6 +17,7 @@ linting via `golangci-lint`/`gosec`/`govulncheck`.
 | Quality Parity with unifi-mcp | ✅ Complete — hardening, CI workflows, interface + tests (PR #32) |
 | Access Control & Audit Tools | ✅ Complete — 83 tools: `list_users`, `list_user_tokens`, `get_node_journal` (PR #34) |
 | Disk Health Tools | ✅ Complete — 86 tools: `get_disk_smart`, `list_zfs_pools`, `get_zfs_pool` (PR #35) |
+| HA & Cluster Config Tools | ✅ Complete — 90 tools: `list_ha_groups`, `list_ha_resources`, `get_ha_status`, `list_cluster_config_nodes` (PR #36) |
 
 ## Decisions
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 | `get_node_status` | Detailed status of a node | `node` |
 | `list_cluster_resources` | All resources across the cluster | `type` (optional: `vm`, `storage`, `node`, `sdn`) |
 | `get_cluster_status` | Cluster status and quorum information | — |
+| `list_ha_groups` | List all HA (High Availability) groups defined in the cluster | — |
+| `list_ha_resources` | List all HA-managed resources (VMs and containers) | — |
+| `get_ha_status` | Current HA manager status, including quorum and per-node/per-resource state | — |
+| `list_cluster_config_nodes` | Corosync nodelist (node names, IDs, ring addresses) | — |
 | `list_node_storage` | Storage pools available on a node | `node` |
 | `list_node_tasks` | Recent tasks on a node | `node`, `limit` (optional) |
 | `get_node_disks` | Physical disks detected on a node | `node` |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An [MCP](https://modelcontextprotocol.io) server that exposes [Proxmox VE](https
 | `get_node_status` | Detailed status of a node | `node` |
 | `list_cluster_resources` | All resources across the cluster | `type` (optional: `vm`, `storage`, `node`, `sdn`) |
 | `get_cluster_status` | Cluster status and quorum information | — |
-| `list_ha_groups` | List all HA (High Availability) groups defined in the cluster | — |
+| `list_ha_groups` | List all HA node-affinity rules (the modern replacement for legacy HA groups) | — |
 | `list_ha_resources` | List all HA-managed resources (VMs and containers) | — |
 | `get_ha_status` | Current HA manager status, including quorum and per-node/per-resource state | — |
 | `list_cluster_config_nodes` | Corosync nodelist (node names, IDs, ring addresses) | — |

--- a/internal/proxmox/cluster.go
+++ b/internal/proxmox/cluster.go
@@ -32,13 +32,17 @@ func (c *Client) GetClusterStatus(ctx context.Context) ([]map[string]any, error)
 	return status, nil
 }
 
-// ListHAGroups returns all HA (High Availability) groups defined in the cluster.
+// ListHAGroups returns all HA (High Availability) node-affinity rules
+// defined in the cluster — the modern replacement for the legacy HA groups
+// concept. PVE versions that have migrated groups to rules return a 500 from
+// the old /cluster/ha/groups endpoint ("ha groups have been migrated to
+// rules"), so this queries /cluster/ha/rules instead.
 func (c *Client) ListHAGroups(ctx context.Context) ([]map[string]any, error) {
-	var groups []map[string]any
-	if err := c.get(ctx, "/cluster/ha/groups", &groups); err != nil {
+	var rules []map[string]any
+	if err := c.get(ctx, "/cluster/ha/rules", &rules); err != nil {
 		return nil, fmt.Errorf("listing HA groups: %w", err)
 	}
-	return groups, nil
+	return rules, nil
 }
 
 // ListHAResources returns all HA-managed resources (VMs and containers) in the cluster.

--- a/internal/proxmox/cluster.go
+++ b/internal/proxmox/cluster.go
@@ -31,3 +31,41 @@ func (c *Client) GetClusterStatus(ctx context.Context) ([]map[string]any, error)
 	}
 	return status, nil
 }
+
+// ListHAGroups returns all HA (High Availability) groups defined in the cluster.
+func (c *Client) ListHAGroups(ctx context.Context) ([]map[string]any, error) {
+	var groups []map[string]any
+	if err := c.get(ctx, "/cluster/ha/groups", &groups); err != nil {
+		return nil, fmt.Errorf("listing HA groups: %w", err)
+	}
+	return groups, nil
+}
+
+// ListHAResources returns all HA-managed resources (VMs and containers) in the cluster.
+func (c *Client) ListHAResources(ctx context.Context) ([]map[string]any, error) {
+	var resources []map[string]any
+	if err := c.get(ctx, "/cluster/ha/resources", &resources); err != nil {
+		return nil, fmt.Errorf("listing HA resources: %w", err)
+	}
+	return resources, nil
+}
+
+// GetHAStatus returns the current status of the HA manager, including quorum
+// and per-node/per-resource state.
+func (c *Client) GetHAStatus(ctx context.Context) ([]map[string]any, error) {
+	var status []map[string]any
+	if err := c.get(ctx, "/cluster/ha/status/current", &status); err != nil {
+		return nil, fmt.Errorf("getting HA status: %w", err)
+	}
+	return status, nil
+}
+
+// ListClusterConfigNodes returns the corosync nodelist for the cluster
+// (node names, IDs, and ring addresses).
+func (c *Client) ListClusterConfigNodes(ctx context.Context) ([]map[string]any, error) {
+	var nodes []map[string]any
+	if err := c.get(ctx, "/cluster/config/nodes", &nodes); err != nil {
+		return nil, fmt.Errorf("listing cluster config nodes: %w", err)
+	}
+	return nodes, nil
+}

--- a/internal/proxmox/cluster_test.go
+++ b/internal/proxmox/cluster_test.go
@@ -130,3 +130,160 @@ func TestGetClusterStatus_notFound(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestListHAGroups_success(t *testing.T) {
+	t.Parallel()
+
+	want := []map[string]any{
+		{"group": "no-pve3", "nodes": "pve1,pve2,pve4"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cluster/ha/groups" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListHAGroups(context.Background())
+	if err != nil {
+		t.Fatalf("ListHAGroups: %v", err)
+	}
+	if len(got) != 1 || got[0]["group"] != "no-pve3" {
+		t.Errorf("got %+v, want 1 group named no-pve3", got)
+	}
+}
+
+func TestListHAGroups_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).ListHAGroups(context.Background())
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestListHAResources_success(t *testing.T) {
+	t.Parallel()
+
+	want := []map[string]any{
+		{"sid": "ct:104", "state": "started"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cluster/ha/resources" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListHAResources(context.Background())
+	if err != nil {
+		t.Fatalf("ListHAResources: %v", err)
+	}
+	if len(got) != 1 || got[0]["sid"] != "ct:104" {
+		t.Errorf("got %+v, want 1 resource ct:104", got)
+	}
+}
+
+func TestListHAResources_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).ListHAResources(context.Background())
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetHAStatus_success(t *testing.T) {
+	t.Parallel()
+
+	want := []map[string]any{
+		{"type": "quorum", "status": "OK"},
+		{"type": "node", "node": "pve1", "status": "online"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cluster/ha/status/current" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).GetHAStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetHAStatus: %v", err)
+	}
+	if len(got) != 2 || got[0]["type"] != "quorum" {
+		t.Errorf("got %+v, want first entry type quorum", got)
+	}
+}
+
+func TestGetHAStatus_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).GetHAStatus(context.Background())
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestListClusterConfigNodes_success(t *testing.T) {
+	t.Parallel()
+
+	want := []map[string]any{
+		{"name": "pve1", "nodeid": float64(1), "ring0_addr": "192.168.4.101"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cluster/config/nodes" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jsonEnvelope(t, want))
+	}))
+	defer srv.Close()
+
+	got, err := newTestClient(t, srv.URL).ListClusterConfigNodes(context.Background())
+	if err != nil {
+		t.Fatalf("ListClusterConfigNodes: %v", err)
+	}
+	if len(got) != 1 || got[0]["name"] != "pve1" {
+		t.Errorf("got %+v, want 1 node named pve1", got)
+	}
+}
+
+func TestListClusterConfigNodes_notFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := newTestClient(t, srv.URL).ListClusterConfigNodes(context.Background())
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/proxmox/cluster_test.go
+++ b/internal/proxmox/cluster_test.go
@@ -135,10 +135,10 @@ func TestListHAGroups_success(t *testing.T) {
 	t.Parallel()
 
 	want := []map[string]any{
-		{"group": "no-pve3", "nodes": "pve1,pve2,pve4"},
+		{"rule": "no-pve3", "type": "node-affinity", "nodes": "pve1,pve2,pve4"},
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/cluster/ha/groups" {
+		if r.URL.Path != "/cluster/ha/rules" {
 			http.NotFound(w, r)
 			return
 		}
@@ -151,8 +151,8 @@ func TestListHAGroups_success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListHAGroups: %v", err)
 	}
-	if len(got) != 1 || got[0]["group"] != "no-pve3" {
-		t.Errorf("got %+v, want 1 group named no-pve3", got)
+	if len(got) != 1 || got[0]["rule"] != "no-pve3" {
+		t.Errorf("got %+v, want 1 rule named no-pve3", got)
 	}
 }
 

--- a/tools/client_iface.go
+++ b/tools/client_iface.go
@@ -61,6 +61,10 @@ type proxmoxClient interface {
 	ListClusterResources(ctx context.Context, resourceType string) ([]proxmox.ClusterResource, error)
 	GetTaskStatus(ctx context.Context, node, upid string) (*proxmox.TaskStatus, error)
 	GetClusterStatus(ctx context.Context) ([]map[string]any, error)
+	ListHAGroups(ctx context.Context) ([]map[string]any, error)
+	ListHAResources(ctx context.Context) ([]map[string]any, error)
+	GetHAStatus(ctx context.Context) ([]map[string]any, error)
+	ListClusterConfigNodes(ctx context.Context) ([]map[string]any, error)
 
 	// Snapshots
 	ListVMSnapshots(ctx context.Context, node string, vmid int) ([]proxmox.Snapshot, error)

--- a/tools/cluster.go
+++ b/tools/cluster.go
@@ -52,4 +52,54 @@ func registerClusterTools(s *mcp.Server, client proxmoxClient) {
 		}
 		return jsonResult(status)
 	})
+
+	type noInput struct{}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_ha_groups",
+		Description: "List all HA (High Availability) groups defined in the cluster.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ noInput) (*mcp.CallToolResult, any, error) {
+		groups, err := client.ListHAGroups(ctx)
+		if err != nil {
+			return errorResult(fmt.Errorf("list_ha_groups: %w", err))
+		}
+		return jsonResult(groups)
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_ha_resources",
+		Description: "List all HA-managed resources (VMs and containers) in the cluster.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ noInput) (*mcp.CallToolResult, any, error) {
+		resources, err := client.ListHAResources(ctx)
+		if err != nil {
+			return errorResult(fmt.Errorf("list_ha_resources: %w", err))
+		}
+		return jsonResult(resources)
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "get_ha_status",
+		Description: "Get the current status of the HA manager, including quorum and per-node/per-resource state.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ noInput) (*mcp.CallToolResult, any, error) {
+		status, err := client.GetHAStatus(ctx)
+		if err != nil {
+			return errorResult(fmt.Errorf("get_ha_status: %w", err))
+		}
+		return jsonResult(status)
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "list_cluster_config_nodes",
+		Description: "List the corosync nodelist for the cluster (node names, IDs, and ring addresses).",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ noInput) (*mcp.CallToolResult, any, error) {
+		nodes, err := client.ListClusterConfigNodes(ctx)
+		if err != nil {
+			return errorResult(fmt.Errorf("list_cluster_config_nodes: %w", err))
+		}
+		return jsonResult(nodes)
+	})
 }

--- a/tools/cluster.go
+++ b/tools/cluster.go
@@ -53,13 +53,13 @@ func registerClusterTools(s *mcp.Server, client proxmoxClient) {
 		return jsonResult(status)
 	})
 
-	type noInput struct{}
+	type listHAGroupsInput struct{}
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_ha_groups",
 		Description: "List all HA (High Availability) groups defined in the cluster.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ noInput) (*mcp.CallToolResult, any, error) {
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listHAGroupsInput) (*mcp.CallToolResult, any, error) {
 		groups, err := client.ListHAGroups(ctx)
 		if err != nil {
 			return errorResult(fmt.Errorf("list_ha_groups: %w", err))
@@ -67,11 +67,13 @@ func registerClusterTools(s *mcp.Server, client proxmoxClient) {
 		return jsonResult(groups)
 	})
 
+	type listHAResourcesInput struct{}
+
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_ha_resources",
 		Description: "List all HA-managed resources (VMs and containers) in the cluster.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ noInput) (*mcp.CallToolResult, any, error) {
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listHAResourcesInput) (*mcp.CallToolResult, any, error) {
 		resources, err := client.ListHAResources(ctx)
 		if err != nil {
 			return errorResult(fmt.Errorf("list_ha_resources: %w", err))
@@ -79,11 +81,13 @@ func registerClusterTools(s *mcp.Server, client proxmoxClient) {
 		return jsonResult(resources)
 	})
 
+	type getHAStatusInput struct{}
+
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_ha_status",
 		Description: "Get the current status of the HA manager, including quorum and per-node/per-resource state.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ noInput) (*mcp.CallToolResult, any, error) {
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ getHAStatusInput) (*mcp.CallToolResult, any, error) {
 		status, err := client.GetHAStatus(ctx)
 		if err != nil {
 			return errorResult(fmt.Errorf("get_ha_status: %w", err))
@@ -91,11 +95,13 @@ func registerClusterTools(s *mcp.Server, client proxmoxClient) {
 		return jsonResult(status)
 	})
 
+	type listClusterConfigNodesInput struct{}
+
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_cluster_config_nodes",
 		Description: "List the corosync nodelist for the cluster (node names, IDs, and ring addresses).",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ noInput) (*mcp.CallToolResult, any, error) {
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listClusterConfigNodesInput) (*mcp.CallToolResult, any, error) {
 		nodes, err := client.ListClusterConfigNodes(ctx)
 		if err != nil {
 			return errorResult(fmt.Errorf("list_cluster_config_nodes: %w", err))

--- a/tools/cluster.go
+++ b/tools/cluster.go
@@ -57,7 +57,7 @@ func registerClusterTools(s *mcp.Server, client proxmoxClient) {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_ha_groups",
-		Description: "List all HA (High Availability) groups defined in the cluster.",
+		Description: "List all HA (High Availability) node-affinity rules defined in the cluster — the modern replacement for the legacy HA groups concept.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ listHAGroupsInput) (*mcp.CallToolResult, any, error) {
 		groups, err := client.ListHAGroups(ctx)

--- a/tools/cluster_test.go
+++ b/tools/cluster_test.go
@@ -94,3 +94,115 @@ func TestGetClusterStatus(t *testing.T) {
 		assertError(t, res, "quorum lost")
 	})
 }
+
+func TestListHAGroups(t *testing.T) {
+	t.Run("returns groups as JSON", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listHAGroupsFn: func(context.Context) ([]map[string]any, error) {
+				return []map[string]any{{"group": "no-pve3"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_ha_groups", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listHAGroupsFn: func(context.Context) ([]map[string]any, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_ha_groups", nil)
+		assertError(t, res, "API error")
+	})
+}
+
+func TestListHAResources(t *testing.T) {
+	t.Run("returns resources as JSON", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listHAResourcesFn: func(context.Context) ([]map[string]any, error) {
+				return []map[string]any{{"sid": "ct:104", "state": "started"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_ha_resources", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listHAResourcesFn: func(context.Context) ([]map[string]any, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_ha_resources", nil)
+		assertError(t, res, "API error")
+	})
+}
+
+func TestGetHAStatus(t *testing.T) {
+	t.Run("returns status as JSON", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			getHAStatusFn: func(context.Context) ([]map[string]any, error) {
+				return []map[string]any{{"type": "quorum", "status": "OK"}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_ha_status", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			getHAStatusFn: func(context.Context) ([]map[string]any, error) {
+				return nil, errors.New("HA manager unreachable")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "get_ha_status", nil)
+		assertError(t, res, "HA manager unreachable")
+	})
+}
+
+func TestListClusterConfigNodes(t *testing.T) {
+	t.Run("returns nodes as JSON", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listClusterConfigNodesFn: func(context.Context) ([]map[string]any, error) {
+				return []map[string]any{{"name": "pve1", "nodeid": 1}}, nil
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_cluster_config_nodes", nil)
+		assertResultJSON(t, res)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		mock := &mockProxmoxClient{
+			listClusterConfigNodesFn: func(context.Context) ([]map[string]any, error) {
+				return nil, errors.New("API error")
+			},
+		}
+		cs, cleanup := connectTestServer(t, mock)
+		defer cleanup()
+
+		res := callTool(t, cs, "list_cluster_config_nodes", nil)
+		assertError(t, res, "API error")
+	})
+}

--- a/tools/cluster_test.go
+++ b/tools/cluster_test.go
@@ -99,7 +99,7 @@ func TestListHAGroups(t *testing.T) {
 	t.Run("returns groups as JSON", func(t *testing.T) {
 		mock := &mockProxmoxClient{
 			listHAGroupsFn: func(context.Context) ([]map[string]any, error) {
-				return []map[string]any{{"group": "no-pve3"}}, nil
+				return []map[string]any{{"rule": "no-pve3", "type": "node-affinity"}}, nil
 			},
 		}
 		cs, cleanup := connectTestServer(t, mock)

--- a/tools/mock_client_test.go
+++ b/tools/mock_client_test.go
@@ -58,9 +58,13 @@ type mockProxmoxClient struct {
 	deleteContainerFn     func(context.Context, string, int, bool) (string, error)
 
 	// Cluster
-	listClusterResourcesFn func(context.Context, string) ([]proxmox.ClusterResource, error)
-	getTaskStatusFn        func(context.Context, string, string) (*proxmox.TaskStatus, error)
-	getClusterStatusFn     func(context.Context) ([]map[string]any, error)
+	listClusterResourcesFn   func(context.Context, string) ([]proxmox.ClusterResource, error)
+	getTaskStatusFn          func(context.Context, string, string) (*proxmox.TaskStatus, error)
+	getClusterStatusFn       func(context.Context) ([]map[string]any, error)
+	listHAGroupsFn           func(context.Context) ([]map[string]any, error)
+	listHAResourcesFn        func(context.Context) ([]map[string]any, error)
+	getHAStatusFn            func(context.Context) ([]map[string]any, error)
+	listClusterConfigNodesFn func(context.Context) ([]map[string]any, error)
 
 	// Snapshots
 	listVMSnapshotsFn           func(context.Context, string, int) ([]proxmox.Snapshot, error)
@@ -432,6 +436,34 @@ func (m *mockProxmoxClient) GetTaskStatus(ctx context.Context, node, upid string
 func (m *mockProxmoxClient) GetClusterStatus(ctx context.Context) ([]map[string]any, error) {
 	if m.getClusterStatusFn != nil {
 		return m.getClusterStatusFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockProxmoxClient) ListHAGroups(ctx context.Context) ([]map[string]any, error) {
+	if m.listHAGroupsFn != nil {
+		return m.listHAGroupsFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockProxmoxClient) ListHAResources(ctx context.Context) ([]map[string]any, error) {
+	if m.listHAResourcesFn != nil {
+		return m.listHAResourcesFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockProxmoxClient) GetHAStatus(ctx context.Context) ([]map[string]any, error) {
+	if m.getHAStatusFn != nil {
+		return m.getHAStatusFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockProxmoxClient) ListClusterConfigNodes(ctx context.Context) ([]map[string]any, error) {
+	if m.listClusterConfigNodesFn != nil {
+		return m.listClusterConfigNodesFn(ctx)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
## Summary
- Add `list_ha_groups` — wraps `GET /cluster/ha/groups`
- Add `list_ha_resources` — wraps `GET /cluster/ha/resources`
- Add `get_ha_status` — wraps `GET /cluster/ha/status/current`
- Add `list_cluster_config_nodes` — wraps `GET /cluster/config/nodes` (corosync nodelist)
- All read-only, registered unconditionally alongside the existing cluster tools

Prompted by the pve2/pve4 watchdog self-fence cascade — diagnosing it needed
raw SSH for `ha-manager config` and `cat /etc/pve/corosync.conf`. This covers
the read side (HA groups/resources/status, corosync nodelist); totem tuning
(token timeout etc.) isn't cleanly API-exposed, so that stays a manual file
edit for now.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — no issues
- [x] `go test ./...` — 393 passed
- [ ] Verify against the live cluster (good test case: `no-pve3` HA group, `pve4-preferred` group)